### PR TITLE
Audio anomalies rework

### DIFF
--- a/src/OSmOSE/utils/audio_utils.py
+++ b/src/OSmOSE/utils/audio_utils.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pandas as pd
+
 from OSmOSE.config import AUDIO_METADATA, SUPPORTED_AUDIO_FORMAT
 
 
@@ -59,3 +61,56 @@ def get_audio_metadata(audio_file: Path) -> dict:
 
     """
     return {key: f(audio_file) for key, f in AUDIO_METADATA.items()}
+
+
+def check_audio(
+    audio_metadata: pd.DataFrame,
+    timestamps: pd.DataFrame,
+) -> None:
+    """Raise errors if the audio files present anomalies.
+
+    Parameters
+    ----------
+    audio_metadata: pandas.DataFrame
+        metadata of the audio files
+    timestamps: pandas.DataFrame
+        timestamps of the audio files
+
+    Raises
+    ------
+    FileNotFoundError:
+        If the number of audio files doesn't match the number of timestamps.
+    ValueError:
+        If the audio files present one of the following anomalies:
+        - Different sampling rates among audio files
+        - Large duration differences (> 5% of the mean duration) among audio files
+
+    """
+    if any(
+        (unlisted_file := file) not in timestamps["filename"].unique()
+        for file in audio_metadata["filename"]
+    ):
+        message = f"{unlisted_file} has not been found in timestamp.csv"
+        raise FileNotFoundError(message)
+
+    if any(
+        (missing_file := filename) not in audio_metadata["filename"].unique()
+        for filename in timestamps["filename"]
+    ):
+        message = f"{missing_file} is listed in timestamp.csv but hasn't be found."
+        raise FileNotFoundError(message)
+
+    if len(audio_metadata["origin_sr"].unique()) > 1:
+        message = (
+            "Your files do not have all the same sampling rate. "
+            f"Found sampling rates: {', '.join(str(sr) + ' Hz' for sr in audio_metadata['origin_sr'].unique())}."
+        )
+        raise ValueError(message)
+
+    mean_duration = audio_metadata["duration"].mean()
+    if any(
+        abs(mean_duration - d) > 0.05 * mean_duration
+        for d in audio_metadata["duration"].unique()
+    ):
+        message = "Your audio files have large duration discrepancies."
+        raise ValueError(message)

--- a/tests/test_audio_utils.py
+++ b/tests/test_audio_utils.py
@@ -1,8 +1,10 @@
+from contextlib import nullcontext as does_not_raise
 from pathlib import Path
 
+import pandas as pd
 import pytest
 
-from OSmOSE.utils.audio_utils import is_supported_audio_format
+from OSmOSE.utils.audio_utils import check_audio, is_supported_audio_format
 
 
 @pytest.mark.unit
@@ -11,7 +13,9 @@ from OSmOSE.utils.audio_utils import is_supported_audio_format
     [
         pytest.param(Path("audio.wav"), True, id="simple_wav_file"),
         pytest.param(
-            Path("audio_with_date_2024_02_14.wav"), True, id="complex_wav_file"
+            Path("audio_with_date_2024_02_14.wav"),
+            True,
+            id="complex_wav_file",
         ),
         pytest.param(Path("parent_folder/audio.wav"), True, id="file_in_parent_folder"),
         pytest.param(Path("audio.flac"), True, id="simple_flac_file"),
@@ -19,7 +23,9 @@ from OSmOSE.utils.audio_utils import is_supported_audio_format
         pytest.param(Path("audio.FLAC"), True, id="uppercase_flac_extension"),
         pytest.param(Path("audio.mp3"), False, id="unsupported_audio_extension"),
         pytest.param(
-            Path("parent_folder/audio.MP3"), False, id="unsupported_in_parent_folder"
+            Path("parent_folder/audio.MP3"),
+            False,
+            id="unsupported_in_parent_folder",
         ),
         pytest.param(Path("audio.pdf"), False, id="unsupported_extension"),
         pytest.param(Path("audio"), False, id="no_extension"),
@@ -27,3 +33,142 @@ from OSmOSE.utils.audio_utils import is_supported_audio_format
 )
 def test_supported_audio_formats(filepath: Path, expected_output: bool) -> None:
     assert is_supported_audio_format(filepath) == expected_output
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("audio_metadata", "timestamps", "expectation"),
+    [
+        pytest.param(
+            pd.DataFrame(
+                [
+                    ["file_1.wav", 128_000, 3_600],
+                    ["file_2.wav", 128_000, 3_600],
+                    ["file_3.wav", 128_000, 3_600],
+                ],
+                columns=["filename", "origin_sr", "duration"],
+            ),
+            pd.DataFrame(
+                [
+                    ["file_1.wav", pd.Timestamp("2024-01-01 12:12:00")],
+                    ["file_2.wav", pd.Timestamp("2024-01-01 12:13:00")],
+                    ["file_3.wav", pd.Timestamp("2024-01-01 12:14:00")],
+                ],
+                columns=["filename", "timestamp"],
+            ),
+            does_not_raise(),
+            id="matching_dfs_do_not_raise",
+        ),
+        pytest.param(
+            pd.DataFrame(
+                [
+                    ["file_1.wav", 128_000, 3_600],
+                    ["file_2.wav", 128_000, 3_600],
+                    ["file_3.wav", 128_000, 3_600],
+                ],
+                columns=["filename", "origin_sr", "duration"],
+            ),
+            pd.DataFrame(
+                [
+                    ["file_1.wav", pd.Timestamp("2024-01-01 12:12:00")],
+                    ["file_2.wav", pd.Timestamp("2024-01-01 12:13:00")],
+                    ["file_4.wav", pd.Timestamp("2024-01-01 12:14:00")],
+                ],
+                columns=["filename", "timestamp"],
+            ),
+            pytest.raises(
+                FileNotFoundError,
+                match="file_3.wav has not been found in timestamp.csv",
+            ),
+            id="missing_file_in_timestamp_csv",
+        ),
+        pytest.param(
+            pd.DataFrame(
+                [["file_1.wav", 128_000, 3_600], ["file_2.wav", 128_000, 3_600]],
+                columns=["filename", "origin_sr", "duration"],
+            ),
+            pd.DataFrame(
+                [
+                    ["file_1.wav", pd.Timestamp("2024-01-01 12:12:00")],
+                    ["file_2.wav", pd.Timestamp("2024-01-01 12:13:00")],
+                    ["file_3.wav", pd.Timestamp("2024-01-01 12:14:00")],
+                ],
+                columns=["filename", "timestamp"],
+            ),
+            pytest.raises(
+                FileNotFoundError,
+                match="file_3.wav is listed in timestamp.csv but hasn't be found.",
+            ),
+            id="missing_audio_file",
+        ),
+        pytest.param(
+            pd.DataFrame(
+                [
+                    ["file_1.wav", 128_000, 3_600],
+                    ["file_2.wav", 128_000, 3_600],
+                    ["file_3.wav", 128_001, 3_600],
+                ],
+                columns=["filename", "origin_sr", "duration"],
+            ),
+            pd.DataFrame(
+                [
+                    ["file_1.wav", pd.Timestamp("2024-01-01 12:12:00")],
+                    ["file_2.wav", pd.Timestamp("2024-01-01 12:13:00")],
+                    ["file_3.wav", pd.Timestamp("2024-01-01 12:14:00")],
+                ],
+                columns=["filename", "timestamp"],
+            ),
+            pytest.raises(
+                ValueError, match="Your files do not have all the same sampling rate."
+            ),
+            id="mismatching_sr",
+        ),
+        pytest.param(
+            pd.DataFrame(
+                [
+                    ["file_1.wav", 128_000, 3_600],
+                    ["file_2.wav", 128_000, 3_600],
+                    ["file_3.wav", 128_000, 1_800],
+                ],
+                columns=["filename", "origin_sr", "duration"],
+            ),
+            pd.DataFrame(
+                [
+                    ["file_1.wav", pd.Timestamp("2024-01-01 12:12:00")],
+                    ["file_2.wav", pd.Timestamp("2024-01-01 12:13:00")],
+                    ["file_3.wav", pd.Timestamp("2024-01-01 12:14:00")],
+                ],
+                columns=["filename", "timestamp"],
+            ),
+            pytest.raises(
+                ValueError, match="Your audio files have large duration discrepancies."
+            ),
+            id="mismatching_duration",
+        ),
+        pytest.param(
+            pd.DataFrame(
+                [
+                    ["file_1.wav", 128_000, 3_580],
+                    ["file_2.wav", 128_000, 3_600],
+                    ["file_3.wav", 128_000, 3_650],
+                ],
+                columns=["filename", "origin_sr", "duration"],
+            ),
+            pd.DataFrame(
+                [
+                    ["file_1.wav", pd.Timestamp("2024-01-01 12:12:00")],
+                    ["file_2.wav", pd.Timestamp("2024-01-01 12:13:00")],
+                    ["file_3.wav", pd.Timestamp("2024-01-01 12:14:00")],
+                ],
+                columns=["filename", "timestamp"],
+            ),
+            does_not_raise(),
+            id="close_durations_should_not_raise",
+        ),
+    ],
+)
+def test_check_audio(
+    audio_metadata: pd.DataFrame, timestamps: pd.DataFrame, expectation: None
+) -> None:
+    with expectation as e:
+        assert check_audio(audio_metadata, timestamps) == e


### PR DESCRIPTION
# Checks the audio files before building:

## Provided timestamp.csv file:
If the `timestamp.csv` file is provided, a check is done to see if all audio files listed in this file are found, and vice versa.

## Audio _anomalies_:
If one of these conditions is true, building is blocked:
- Audio files do not all have the same sampling rate
- Any audio file has a duration outside `±5%` of the mean duration

## Bypassing the checks:
If the `force_init` parameter is set to `True`, test results are logged but bypassed.
If an incorrect `timestamp.csv` file was found, it is moved to the `other` folder.