### PR TITLE
Npz file concat

### DIFF
--- a/src/OSmOSE/config.py
+++ b/src/OSmOSE/config.py
@@ -33,7 +33,7 @@ OSMOSE_PATH = namedtuple("path_list", __global_path_dict.keys())(**__global_path
 
 TIMESTAMP_FORMAT_AUDIO_FILE = "%Y-%m-%dT%H:%M:%S.%f%z"
 TIMESTAMP_FORMAT_TEST_FILES = "%y%m%d%H%M%S%f"
-TIMESTAMP_FORMAT_EXPORTED_FILES = "%Y_%m_%d_%H_%M_%S"
+TIMESTAMP_FORMAT_EXPORTED_FILES = "%Y_%m_%d_%H_%M_%S_%f"
 FPDEFAULT = 0o664  # Default file permissions
 DPDEFAULT = stat.S_ISGID | 0o775  # Default directory permissions
 

--- a/src/OSmOSE/data/audio_data.py
+++ b/src/OSmOSE/data/audio_data.py
@@ -178,7 +178,9 @@ class AudioData(BaseData[AudioItem, AudioFile]):
         if stop_frame < -1 or stop_frame > self.shape:
             raise ValueError("Stop_frame must be lower than the length of the data.")
 
-        start_timestamp = self.begin + Timedelta(seconds=start_frame / self.sample_rate)
+        start_timestamp = self.begin + Timedelta(
+            seconds=round(start_frame / self.sample_rate, 9)
+        )
         stop_timestamp = (
             self.end
             if stop_frame == -1

--- a/src/OSmOSE/data/audio_data.py
+++ b/src/OSmOSE/data/audio_data.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 import soundfile as sf
+from pandas import Timedelta
 
 from OSmOSE.config import TIMESTAMP_FORMAT_EXPORTED_FILES
 from OSmOSE.data.audio_file import AudioFile
@@ -155,6 +156,40 @@ class AudioData(BaseData[AudioItem, AudioFile]):
             AudioData.from_base_data(base_data, self.sample_rate)
             for base_data in super().split(nb_subdata)
         ]
+
+    def split_frames(self, start_frame: int = 0, stop_frame: int = -1) -> AudioData:
+        """Return a new AudioData from a subpart of this AudioData's data.
+
+        Parameters
+        ----------
+        start_frame: int
+            First frame included in the new AudioData.
+        stop_frame: int
+            First frame after the last frame included in the new AudioData.
+
+        Returns
+        -------
+        AudioData
+            A new AudioData which data is included between start_frame and stop_frame.
+
+        """
+        if start_frame < 0:
+            raise ValueError("Start_frame must be greater than or equal to 0.")
+        if stop_frame < -1 or stop_frame >= self.shape[0]:
+            raise ValueError("Stop_frame must be lower than the length of the data.")
+
+        start_timestamp = self.begin + Timedelta(seconds=start_frame / self.sample_rate)
+        stop_timestamp = (
+            self.end
+            if stop_frame == -1
+            else self.begin + Timedelta(seconds=stop_frame / self.sample_rate)
+        )
+        return AudioData.from_files(
+            list(self.files),
+            start_timestamp,
+            stop_timestamp,
+            sample_rate=self.sample_rate,
+        )
 
     @classmethod
     def from_files(

--- a/src/OSmOSE/data/audio_data.py
+++ b/src/OSmOSE/data/audio_data.py
@@ -175,7 +175,7 @@ class AudioData(BaseData[AudioItem, AudioFile]):
         """
         if start_frame < 0:
             raise ValueError("Start_frame must be greater than or equal to 0.")
-        if stop_frame < -1 or stop_frame >= self.shape[0]:
+        if stop_frame < -1 or stop_frame > self.shape:
             raise ValueError("Stop_frame must be lower than the length of the data.")
 
         start_timestamp = self.begin + Timedelta(seconds=start_frame / self.sample_rate)

--- a/src/OSmOSE/data/audio_file.py
+++ b/src/OSmOSE/data/audio_file.py
@@ -92,8 +92,8 @@ class AudioFile(BaseFile):
             First and last frames of the data.
 
         """
-        start_sample = floor((start - self.begin).total_seconds() * self.sample_rate)
-        stop_sample = round((stop - self.begin).total_seconds() * self.sample_rate)
+        start_sample = floor(((start - self.begin) * self.sample_rate).total_seconds())
+        stop_sample = round(((stop - self.begin) * self.sample_rate).total_seconds())
         return start_sample, stop_sample
 
     @classmethod

--- a/src/OSmOSE/data/spectro_data.py
+++ b/src/OSmOSE/data/spectro_data.py
@@ -184,6 +184,7 @@ class SpectroData(BaseData[SpectroItem, SpectroFile]):
         hop = [self.fft.hop]
         fs = [self.fft.fs]
         mfft = [self.fft.mfft]
+        timestamps = (str(t) for t in (self.begin, self.end))
         np.savez(
             file=folder / f"{self}.npz",
             fs=fs,
@@ -193,6 +194,7 @@ class SpectroData(BaseData[SpectroItem, SpectroFile]):
             hop=hop,
             sx=sx,
             mfft=mfft,
+            timestamps="_".join(timestamps),
         )
 
     def split(self, nb_subdata: int = 2) -> list[SpectroData]:
@@ -210,7 +212,7 @@ class SpectroData(BaseData[SpectroItem, SpectroFile]):
 
         """
         split_frames = list(
-            np.linspace(0, self.audio_data.shape, nb_subdata + 1, dtype=int)
+            np.linspace(0, self.audio_data.shape, nb_subdata + 1, dtype=int),
         )
         split_frames = [
             self.fft.nearest_k_p(frame) if idx < (len(split_frames) - 1) else frame

--- a/src/OSmOSE/data/spectro_data.py
+++ b/src/OSmOSE/data/spectro_data.py
@@ -178,11 +178,7 @@ class SpectroData(BaseData[SpectroItem, SpectroFile]):
         """
         super().create_directories(path=folder)
         sx = self.get_value() if sx is None else sx
-        time = (
-            self.fft.t(self.audio_data.shape)
-            if self.audio_data is not None
-            else next(self.files).time
-        )
+        time = np.arange(sx.shape[1]) * self.duration.total_seconds() / sx.shape[1]
         freq = self.fft.f
         window = self.fft.win
         hop = [self.fft.hop]

--- a/src/OSmOSE/data/spectro_data.py
+++ b/src/OSmOSE/data/spectro_data.py
@@ -178,7 +178,11 @@ class SpectroData(BaseData[SpectroItem, SpectroFile]):
         """
         super().create_directories(path=folder)
         sx = self.get_value() if sx is None else sx
-        time = np.arange(sx.shape[1]) * self.duration.total_seconds() / sx.shape[1]
+        time = (
+            self.fft.t(self.audio_data.shape)
+            if self.audio_data is not None
+            else next(self.files).time
+        )
         freq = self.fft.f
         window = self.fft.win
         hop = [self.fft.hop]

--- a/src/OSmOSE/data/spectro_data.py
+++ b/src/OSmOSE/data/spectro_data.py
@@ -127,7 +127,7 @@ class SpectroData(BaseData[SpectroItem, SpectroFile]):
         if not self.audio_data or not self.fft:
             raise ValueError("SpectroData should have either items or audio_data.")
 
-        return self.fft.spectrogram(self.audio_data.get_value(), padding="even")
+        return self.fft.stft(self.audio_data.get_value(), padding="zeros")
 
     def plot(self, ax: plt.Axes | None = None, sx: np.ndarray | None = None) -> None:
         """Plot the spectrogram on a specific Axes.
@@ -143,7 +143,7 @@ class SpectroData(BaseData[SpectroItem, SpectroFile]):
         """
         ax = ax if ax is not None else SpectroData.get_default_ax()
         sx = self.get_value() if sx is None else sx
-        sx = 10 * np.log10(abs(sx) + np.nextafter(0, 1))
+        sx = 10 * np.log10(abs(sx) ** 2 + np.nextafter(0, 1))
         time = np.arange(sx.shape[1]) * self.duration.total_seconds() / sx.shape[1]
         freq = self.fft.f
         ax.pcolormesh(time, freq, sx, vmin=-120, vmax=0)
@@ -195,6 +195,34 @@ class SpectroData(BaseData[SpectroItem, SpectroFile]):
             mfft=mfft,
         )
 
+    def split(self, nb_subdata: int = 2) -> list[SpectroData]:
+        """Split the spectro data object in the specified number of spectro subdata.
+
+        Parameters
+        ----------
+        nb_subdata: int
+            Number of subdata in which to split the data.
+
+        Returns
+        -------
+        list[SpectroData]
+            The list of SpectroData subdata objects.
+
+        """
+        split_frames = list(
+            np.linspace(0, self.audio_data.shape, nb_subdata + 1, dtype=int)
+        )
+        split_frames = [
+            self.fft.nearest_k_p(frame) if idx < (len(split_frames) - 1) else frame
+            for idx, frame in enumerate(split_frames)
+        ]
+
+        ad_split = [
+            self.audio_data.split_frames(start_frame=a, stop_frame=b)
+            for a, b in zip(split_frames, split_frames[1:])
+        ]
+        return [SpectroData.from_audio_data(ad, self.fft) for ad in ad_split]
+
     def _get_value_from_items(self, items: list[SpectroItem]) -> np.ndarray:
         if not all(
             np.array_equal(items[0].file.freq, i.file.freq)
@@ -208,11 +236,11 @@ class SpectroData(BaseData[SpectroItem, SpectroFile]):
 
         output = items[0].get_value(fft=self.fft)
         for item in items[1:]:
-            p1_le = self.fft.lower_border_end[1] - self.fft.p_min - 1
+            p1_le = self.fft.lower_border_end[1] - self.fft.p_min
             output = np.hstack(
                 (
                     output[:, :-p1_le],
-                    (output[:, -p1_le:] + item.get_value(fft=self.fft)[:, :p1_le]) / 2,
+                    (output[:, -p1_le:] + item.get_value(fft=self.fft)[:, :p1_le]),
                     item.get_value(fft=self.fft)[:, p1_le:],
                 ),
             )

--- a/src/OSmOSE/data/spectro_dataset.py
+++ b/src/OSmOSE/data/spectro_dataset.py
@@ -43,6 +43,18 @@ class SpectroDataset(BaseDataset[SpectroData, SpectroFile]):
         for data in self.data:
             data.fft = fft
 
+    def save_spectrogram(self, folder: Path) -> None:
+        """Export all spectrogram data as png images in the specified folder.
+
+        Parameters
+        ----------
+        folder: Path
+            Folder in which the spectrograms should be saved.
+
+        """
+        for data in self.data:
+            data.save_spectrogram(folder)
+
     @classmethod
     def from_folder(
         cls,

--- a/src/OSmOSE/data/spectro_file.py
+++ b/src/OSmOSE/data/spectro_file.py
@@ -62,22 +62,15 @@ class SpectroFile(BaseFile):
             hop = int(data["hop"][0])
             window = data["window"]
             mfft = data["mfft"][0]
+            timestamps = str(data["timestamps"])
 
         self.sample_rate = sample_rate
         self.mfft = mfft
 
-        delta_times = [
-            Timedelta(seconds=time[i] - time[i - 1]).round(freq="ns")
-            for i in range(1, time.shape[0])
-        ]
-        most_frequent_delta_time = max(
-            ((v, delta_times.count(v)) for v in set(delta_times)),
-            key=lambda i: i[1],
-        )[0]
-        self.time_resolution = most_frequent_delta_time
-        self.end = (
-            self.begin + Timedelta(seconds=time[-1]) + self.time_resolution
-        ).round(freq="us")
+        self.begin, self.end = (Timestamp(t) for t in timestamps.split("_"))
+
+        self.time = time
+        self.time_resolution = (self.end - self.begin) / len(self.time)
 
         self.freq = freq
 

--- a/src/OSmOSE/utils/audio_utils.py
+++ b/src/OSmOSE/utils/audio_utils.py
@@ -203,4 +203,4 @@ def resample(data: np.ndarray, origin_sr: float, target_sr: float) -> np.ndarray
         The resampled audio data.
 
     """
-    return soxr.resample(data, origin_sr, target_sr)
+    return soxr.resample(data, origin_sr, target_sr, quality="QQ")

--- a/tests/test_spectro.py
+++ b/tests/test_spectro.py
@@ -142,7 +142,10 @@ def test_spectro_parameters_in_npz_files(
     assert sf.hop == sft.hop
     assert sf.mfft == sft.mfft
     assert sf.sample_rate == sft.fs
-    assert np.array_equal(sf.time, sft.t(ad.shape))
+    nb_time_bins = sft.t(ad.shape).shape[0]
+    assert np.array_equal(
+        sf.time, np.arange(nb_time_bins) * ad.duration.total_seconds() / nb_time_bins
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_spectro.py
+++ b/tests/test_spectro.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pandas as pd
+import pytest
+from scipy.signal import ShortTimeFFT
+from scipy.signal.windows import hamming
+
+from OSmOSE.config import TIMESTAMP_FORMAT_EXPORTED_FILES, TIMESTAMP_FORMAT_TEST_FILES
+from OSmOSE.data.audio_data import AudioData
+from OSmOSE.data.audio_dataset import AudioDataset
+from OSmOSE.data.audio_file import AudioFile
+from OSmOSE.data.spectro_data import SpectroData
+from OSmOSE.data.spectro_dataset import SpectroDataset
+from OSmOSE.utils.audio_utils import generate_sample_audio
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.mark.parametrize(
+    ("audio_files", "original_audio_data", "sft"),
+    [
+        pytest.param(
+            {
+                "duration": 1,
+                "sample_rate": 48_000,
+                "nb_files": 1,
+                "date_begin": pd.Timestamp("2024-01-01 12:00:00"),
+            },
+            generate_sample_audio(1, 48_000, dtype=np.float64),
+            ShortTimeFFT(hamming(1_024), 1024, 48_000),
+            id="short_spectrogram",
+        ),
+        pytest.param(
+            {
+                "duration": 1,
+                "sample_rate": 1_024,
+                "nb_files": 1,
+                "date_begin": pd.Timestamp("2024-01-01 12:00:00"),
+            },
+            generate_sample_audio(1, 1_024, dtype=np.float64),
+            ShortTimeFFT(hamming(1_024), 1024, 1_024),
+            id="data_is_one_window_long",
+        ),
+    ],
+    indirect=["audio_files"],
+)
+def test_spectrogram_shape(
+    tmp_path: Path,
+    audio_files: tuple[list[Path], pytest.fixtures.Subrequest],
+    original_audio_data: list[np.ndarray],
+    sft: ShortTimeFFT,
+) -> None:
+    dataset = AudioDataset.from_folder(
+        tmp_path,
+        strptime_format=TIMESTAMP_FORMAT_TEST_FILES,
+    )
+    spectro_dataset = SpectroDataset.from_audio_dataset(dataset, sft)
+    for audio, spectro in zip(dataset.data, spectro_dataset.data):
+        assert spectro.shape == spectro.get_value().shape
+        assert spectro.shape == (sft.f.shape[0], sft.p_num(audio.shape))
+
+@pytest.mark.parametrize(
+    ("audio_files", "nb_chunks", "sft"),
+    [
+        pytest.param(
+            {
+                "duration": 6,
+                "sample_rate": 1_024,
+                "nb_files": 1,
+                "date_begin": pd.Timestamp("2024-01-01 12:00:00"),
+            },
+            3,
+            ShortTimeFFT(hamming(1_024), 1_024, 1_024),
+            id="6_seconds_split_in_3",
+        ),
+        pytest.param(
+            {
+                "duration": 1,
+                "sample_rate": 1_024,
+                "nb_files": 1,
+                "date_begin": pd.Timestamp("2024-01-01 12:00:00"),
+            },
+            1,
+            ShortTimeFFT(hamming(1_024), 100, 1_024),
+            id="1_npz_file",
+        ),
+        pytest.param(
+            {
+                "duration": 6,
+                "sample_rate": 1_024,
+                "nb_files": 1,
+                "date_begin": pd.Timestamp("2024-01-01 12:00:00"),
+            },
+            3,
+            ShortTimeFFT(hamming(1_024), 100, 1_024),
+            id="6_seconds_split_in_3_with_overlap",
+        ),
+        pytest.param(
+            {
+                "duration": 8,
+                "sample_rate": 1_024,
+                "nb_files": 1,
+                "date_begin": pd.Timestamp("2024-01-01 12:00:00"),
+            },
+            4,
+            ShortTimeFFT(hamming(1_024), 100, 1_024),
+            id="8_seconds_split_in_4",
+        ),
+        pytest.param(
+            {
+                "duration": 4,
+                "sample_rate": 48_000,
+                "nb_files": 1,
+                "date_begin": pd.Timestamp("2024-01-01 12:00:00"),
+            },
+            4,
+            ShortTimeFFT(hamming(12_000), 12_000, 48_000),
+            id="high_sr_no_overlap",
+        ),
+        pytest.param(
+            {
+                "duration": 2,
+                "sample_rate": 48_000,
+                "nb_files": 1,
+                "date_begin": pd.Timestamp("2024-01-01 12:00:00"),
+            },
+            3,
+            ShortTimeFFT(hamming(12_000), 10_000, 48_000),
+            id="high_sr_overlap",
+        ),
+        pytest.param(
+            {
+                "duration": 6,
+                "sample_rate": 1_024,
+                "nb_files": 1,
+                "date_begin": pd.Timestamp("2024-01-01 12:00:00"),
+            },
+            6,
+            ShortTimeFFT(hamming(1_024), 1_024, 1_024),
+            id="6_seconds_split_in_6",
+        ),
+        pytest.param(
+            {
+                "duration": 6,
+                "sample_rate": 1_024,
+                "nb_files": 1,
+                "date_begin": pd.Timestamp("2024-01-01 12:00:00"),
+            },
+            6,
+            ShortTimeFFT(hamming(1_024), 100, 1_024),
+            id="6_seconds_split_in_6_with_overlap",
+        ),
+    ],
+    indirect=["audio_files"],
+)
+def test_spectrogram_from_npz_files(
+    tmp_path: Path,
+    audio_files: tuple[list[Path], pytest.fixtures.Subrequest],
+    nb_chunks: int,
+    sft: ShortTimeFFT,
+) -> None:
+    afs = [
+        AudioFile(f, strptime_format=TIMESTAMP_FORMAT_TEST_FILES)
+        for f in tmp_path.glob("*.wav")
+    ]
+
+    ad = AudioData.from_files(afs)
+    sd = SpectroData.from_audio_data(ad, sft)
+
+    sd_split = sd.split(nb_chunks)
+
+    for spectro in sd_split:
+        spectro.write(tmp_path / "output")
+    assert len(list((tmp_path / "output").glob("*.npz"))) == nb_chunks
+
+    sds = SpectroDataset.from_folder(
+        tmp_path / "output",
+        TIMESTAMP_FORMAT_EXPORTED_FILES,
+    )
+
+    assert sds.begin == ad.begin
+    assert sds.duration == ad.duration
+    assert len(sds.data) == 1
+    assert sds.data[0].shape == sds.data[0].get_value().shape
+
+    assert sds.data[0].shape == (
+        sft.f.shape[0],
+        sft.p_num(int(ad.duration.total_seconds() * ad.sample_rate)),
+    )
+
+    assert np.allclose(sd.get_value(), sds.data[0].get_value())


### PR DESCRIPTION
This PR fixes the concatenation of multiple NPZ files to form a larger spectrogram as LTAS were computed in the legacy OSEkit.

It introduces the `split()` method for `SpectroData` objects, which deviates from the behaviour of `AudioData.split()` as it forces the chunks to be made [on frames on which a window of the SFT is centered](https://docs.scipy.org/doc/scipy-1.15.0/reference/generated/scipy.signal.ShortTimeFFT.nearest_k_p.html). This is required to reconstruct a sft from sft parts, as shown in the ["It is possible to calculate the SFT of signal parts:" section](https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.ShortTimeFFT.html#scipy.signal.ShortTimeFFT).

This PR also improves the accuracy of the SpectroFile objects begin/end timestamps by **writting the timestamps in the npz file**, rather than computing it in a pretty questionable way as it was done before 🥸.
