### PR TITLE
add lock file to prevent jobs for editing json files simultaneously

### DIFF
--- a/src/OSmOSE/public_api/export_analysis.py
+++ b/src/OSmOSE/public_api/export_analysis.py
@@ -2,17 +2,16 @@ from __future__ import annotations
 
 import argparse
 import os
-import time
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from OSmOSE.config import resample_quality_settings
-from OSmOSE.core_api.spectro_dataset import SpectroDataset
 from OSmOSE.public_api import Analysis
 from OSmOSE.public_api.dataset import Dataset
 
 if TYPE_CHECKING:
     from OSmOSE.core_api.audio_dataset import AudioDataset
+    from OSmOSE.core_api.spectro_dataset import SpectroDataset
 
 
 def write_analysis(
@@ -93,29 +92,7 @@ def write_analysis(
         )
 
     # Update the sds from the JSON in case it has already been modified in another job
-    _update_json(sds=sds, first=first, last=last)
-
-
-def _update_json(
-    sds: SpectroDataset, first: int, last: int, lockfile_name: str = "lock.lock"
-) -> None:
-
-    lock_file = sds.folder / lockfile_name
-
-    # Wait for the lock to be released
-    while lock_file.exists():
-        time.sleep(1)
-
-    # Create lock file
-    lock_file.touch()
-
-    sd_to_update = sds.data[first:last]
-    sds = SpectroDataset.from_json(sds.folder / f"{sds.name}.json")
-    sds.data[first:last] = sd_to_update
-
-    sds.write_json(sds.folder)
-
-    lock_file.unlink()
+    sds.update_json_audio_data(first=first, last=last)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# 🐳 What's going on?

JSON files are updated after each analysis. 
When multiple analyses run simultaneously over several jobs, I have to prevent scripts to edit simultaneously a same JSON file, otherwise only one of the edit might be taken into account.

# 🐳 When does it happen?

For now, it only happens after analyses that mix both `AUDIO` and spectro (`MATRIX` and/or `SPECTROGRAM`) flags. 

After exporting the reshaped audio files, we use these new files to compute the spectra. 
Hence, we want to update the `SpectroDataset` JSON file to link the `SpectroData` to the new audio files. 

# 🐳 How does it work?

After running an analysis that contains spectro flags, the `SpectroDataset` JSON file is edited this way:

- If there is an existing `lock.lock` file: another job is editing the JSON file, we wait.
- If there is no `lock.lock` file: no other job is trying to edit the JSON file: all clear.
- We create an empty `lock.lock` file to prevent other jobs from editing the JSON file.
- We edit the JSON file
- We delete the `lock.lock` file.