### PR TITLE
Colormap

### DIFF
--- a/docs/source/_static/audio_data/ex1.svg
+++ b/docs/source/_static/audio_data/ex1.svg
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="75.454269mm"
+   height="74.770668mm"
+   viewBox="0 0 75.454269 74.770668"
+   version="1.1"
+   id="svg1"
+   sodipodi:docname="ex1.svg"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
+   inkscape:export-batch-path="C:\Users\berthoga\Documents\Communications\OSEkit_rework\media\audio_data"
+   inkscape:export-batch-name="ex1"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm"
+     inkscape:zoom="1.4142136"
+     inkscape:cx="544.47222"
+     inkscape:cy="297.3384"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1"
+     showgrid="false">
+    <inkscape:page
+       x="0"
+       y="0"
+       width="75.454269"
+       height="74.770668"
+       id="page3"
+       margin="0"
+       bleed="0"
+       inkscape:label="3" />
+  </sodipodi:namedview>
+  <defs
+     id="defs1" />
+  <g
+     inkscape:label="Calque 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-257.56423,-79.501804)">
+    <g
+       id="g17"
+       transform="translate(170.90854)">
+      <rect
+         style="fill:none;stroke:#e74c3c;stroke-width:0.705001;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect10"
+         width="74.749268"
+         height="17.585871"
+         x="87.008194"
+         y="131.6265"
+         rx="2.7602232"
+         ry="2.7602232" />
+      <rect
+         style="fill:none;stroke:#3498db;stroke-width:0.705;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect11"
+         width="21.742594"
+         height="17.585871"
+         x="87.008194"
+         y="108.0942"
+         rx="2.7602232"
+         ry="2.7602232" />
+      <rect
+         style="fill:none;stroke:#2ecc71;stroke-width:0.705;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect12"
+         width="21.742594"
+         height="17.585871"
+         x="87.008194"
+         y="84.561913"
+         rx="2.7602232"
+         ry="2.7602232" />
+      <path
+         style="fill:#87de87;stroke:#cccccc;stroke-width:0.3;stroke-linecap:round;stroke-dasharray:0.899999, 0.899999;stroke-dashoffset:0"
+         d="M 108.75079,79.651804 V 154.12247"
+         id="path12" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.175px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';text-align:center;writing-mode:lr-tb;direction:ltr;white-space:pre-wrap;shape-inside:url(#rect10);display:inline;fill:#e74c3c;fill-opacity:1;stroke:#d35f5f;stroke-width:0.705001;stroke-linecap:round;stroke-dasharray:none"
+         x="53.788872"
+         y="225.38052"
+         id="text13"><tspan
+           x="120.47511"
+           y="134.40508"
+           id="tspan2"><tspan
+             style="stroke:none;stroke-width:0.705"
+             id="tspan1">FILE</tspan></tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.175px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';text-align:center;writing-mode:lr-tb;direction:ltr;white-space:pre-wrap;shape-inside:url(#rect11);display:inline;fill:#3498db;fill-opacity:1;stroke:#d35f5f;stroke-width:0.705001;stroke-linecap:round;stroke-dasharray:none"
+         x="53.788872"
+         y="225.38052"
+         id="text15"><tspan
+           x="93.971207"
+           y="110.87187"
+           id="tspan4"><tspan
+             style="stroke:none"
+             id="tspan3">ITEM</tspan></tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.175px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';text-align:center;writing-mode:lr-tb;direction:ltr;white-space:pre-wrap;shape-inside:url(#rect12);display:inline;fill:#2ecc71;fill-opacity:1;stroke:#d35f5f;stroke-width:0.705001;stroke-linecap:round;stroke-dasharray:none"
+         x="53.788872"
+         y="225.38052"
+         id="text17"><tspan
+           x="93.971207"
+           y="87.340625"
+           id="tspan6"><tspan
+             style="stroke:none"
+             id="tspan5">DATA</tspan></tspan></text>
+    </g>
+  </g>
+</svg>

--- a/docs/source/_static/audio_data/ex2.svg
+++ b/docs/source/_static/audio_data/ex2.svg
@@ -1,0 +1,310 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="75.454269mm"
+   height="74.770668mm"
+   viewBox="0 0 75.454269 74.770668"
+   version="1.1"
+   id="svg1"
+   sodipodi:docname="ex2.svg"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
+   inkscape:export-batch-path="C:\Users\berthoga\Documents\Communications\OSEkit_rework\media\audio_data"
+   inkscape:export-batch-name="ex2"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm"
+     inkscape:zoom="0.5"
+     inkscape:cx="264"
+     inkscape:cy="109"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1"
+     showgrid="false">
+    <inkscape:page
+       x="0"
+       y="0"
+       width="75.454269"
+       height="74.770668"
+       id="page3"
+       margin="0"
+       bleed="0"
+       inkscape:label="3" />
+  </sodipodi:namedview>
+  <defs
+     id="defs1" />
+  <g
+     inkscape:label="Calque 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-257.56423,-79.501804)">
+    <g
+       id="g79">
+      <rect
+         style="fill:none;stroke:#2ecc71;stroke-width:0.705;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect12"
+         width="74.749252"
+         height="17.585871"
+         x="257.91675"
+         y="84.561913"
+         rx="2.7602232"
+         ry="2.7602232" />
+      <g
+         id="g23"
+         transform="matrix(0.78131261,0,0,1,56.678543,0)"
+         style="stroke-width:1.13133">
+        <rect
+           style="fill:none;stroke:#e74c3c;stroke-width:0.797586;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+           id="rect10"
+           width="18.863583"
+           height="17.585871"
+           x="257.56424"
+           y="131.6265"
+           rx="3.5328023"
+           ry="2.7602232" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.175px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';text-align:center;writing-mode:lr-tb;direction:ltr;white-space:pre-wrap;shape-inside:url(#rect10);display:inline;fill:#e74c3c;fill-opacity:1;stroke:#d35f5f;stroke-width:0.797586;stroke-linecap:round;stroke-dasharray:none"
+           x="53.788872"
+           y="225.38052"
+           id="text13"><tspan
+             x="263.0884"
+             y="134.40508"
+             id="tspan4"><tspan
+               style="stroke:none;stroke-width:0.797585"
+               id="tspan3">FILE</tspan></tspan></text>
+      </g>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.175px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';text-align:center;writing-mode:lr-tb;direction:ltr;white-space:pre-wrap;shape-inside:url(#rect12);display:inline;fill:#2ecc71;fill-opacity:1;stroke:#d35f5f;stroke-width:0.705001;stroke-linecap:round;stroke-dasharray:none"
+         x="53.788872"
+         y="225.38052"
+         id="text17"><tspan
+           x="291.38382"
+           y="87.340625"
+           id="tspan6"><tspan
+             style="stroke:none"
+             id="tspan5">DATA</tspan></tspan></text>
+      <g
+         id="g23-5"
+         transform="matrix(0.80061052,0,0,1,66.434913,0)"
+         style="stroke-width:1.11761">
+        <rect
+           style="fill:none;stroke:#e74c3c;stroke-width:0.787915;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+           id="rect10-5"
+           width="18.863583"
+           height="17.585871"
+           x="257.56424"
+           y="131.6265"
+           rx="3.4476478"
+           ry="2.7602232" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.175px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';text-align:center;writing-mode:lr-tb;direction:ltr;white-space:pre-wrap;shape-inside:url(#rect10-5);display:inline;fill:#e74c3c;fill-opacity:1;stroke:#d35f5f;stroke-width:0.787915;stroke-linecap:round;stroke-dasharray:none"
+           x="53.788872"
+           y="225.38052"
+           id="text13-1"><tspan
+             x="263.0884"
+             y="134.40508"
+             id="tspan8"><tspan
+               style="stroke:none;stroke-width:0.787913"
+               id="tspan7">FILE</tspan></tspan></text>
+      </g>
+      <g
+         id="g24"
+         transform="matrix(0.800244,0,0,1,81.629395,0)"
+         style="stroke-width:1.11786">
+        <rect
+           style="fill:none;stroke:#e74c3c;stroke-width:0.788095;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+           id="rect23"
+           width="18.863583"
+           height="17.585871"
+           x="257.56424"
+           y="131.6265"
+           rx="3.4492269"
+           ry="2.7602232" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.175px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';text-align:center;writing-mode:lr-tb;direction:ltr;white-space:pre-wrap;shape-inside:url(#rect23);display:inline;fill:#e74c3c;fill-opacity:1;stroke:#d35f5f;stroke-width:0.788095;stroke-linecap:round;stroke-dasharray:none"
+           x="53.788872"
+           y="225.38052"
+           id="text24"><tspan
+             x="263.0884"
+             y="134.40508"
+             id="tspan10"><tspan
+               style="stroke:none;stroke-width:0.788093"
+               id="tspan9">FILE</tspan></tspan></text>
+      </g>
+      <g
+         id="g26"
+         transform="matrix(0.78150084,0,0,1,116.64098,0)"
+         style="stroke-width:1.13119">
+        <rect
+           style="fill:none;stroke:#e74c3c;stroke-width:0.79749;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+           id="rect24"
+           width="18.863583"
+           height="17.585871"
+           x="257.56424"
+           y="131.6265"
+           rx="3.5319514"
+           ry="2.7602232" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.175px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';text-align:center;writing-mode:lr-tb;direction:ltr;white-space:pre-wrap;shape-inside:url(#rect24);display:inline;fill:#e74c3c;fill-opacity:1;stroke:#d35f5f;stroke-width:0.79749;stroke-linecap:round;stroke-dasharray:none"
+           x="53.788872"
+           y="225.38052"
+           id="text26"><tspan
+             x="263.0884"
+             y="134.40508"
+             id="tspan12"><tspan
+               style="stroke:none;stroke-width:0.797489"
+               id="tspan11">FILE</tspan></tspan></text>
+      </g>
+      <g
+         id="g28"
+         transform="matrix(0.781241,0,0,1,56.697663,-23.535636)"
+         style="stroke:#3498db;stroke-width:1.13138;stroke-opacity:1">
+        <rect
+           style="fill:none;stroke:#3498db;stroke-width:0.797623;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+           id="rect26"
+           width="18.863583"
+           height="17.585871"
+           x="257.56424"
+           y="131.6265"
+           rx="3.5331261"
+           ry="2.7602232" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.175px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';text-align:center;writing-mode:lr-tb;direction:ltr;white-space:pre-wrap;shape-inside:url(#rect26);display:inline;fill:#3498db;fill-opacity:1;stroke:none;stroke-width:0.797623;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+           x="53.788872"
+           y="225.38052"
+           id="text28"><tspan
+             x="263.0884"
+             y="134.40508"
+             id="tspan13">ITEM</tspan></text>
+      </g>
+      <g
+         id="g30"
+         transform="matrix(0.79945891,0,0,1,66.742389,-23.535636)"
+         style="stroke:#3498db;stroke-width:1.11841;stroke-opacity:1">
+        <rect
+           style="fill:none;stroke:#3498db;stroke-width:0.788482;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+           id="rect28"
+           width="18.863583"
+           height="17.585871"
+           x="257.56424"
+           y="131.6265"
+           rx="3.4526141"
+           ry="2.7602232" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.175px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';text-align:center;writing-mode:lr-tb;direction:ltr;white-space:pre-wrap;shape-inside:url(#rect28);display:inline;fill:#3498db;fill-opacity:1;stroke:none;stroke-width:0.788482;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+           x="53.788872"
+           y="225.38052"
+           id="text30"><tspan
+             x="263.08838"
+             y="134.40508"
+             id="tspan14">ITEM</tspan></text>
+      </g>
+      <g
+         id="g32"
+         transform="matrix(0.80115102,0,0,1,81.387224,-23.535636)"
+         style="stroke:#3498db;stroke-width:1.11723;stroke-opacity:1">
+        <rect
+           style="fill:none;stroke:#3498db;stroke-width:0.787649;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+           id="rect30"
+           width="18.863583"
+           height="17.585871"
+           x="257.56424"
+           y="131.6265"
+           rx="3.4453218"
+           ry="2.7602232" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.175px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';text-align:center;writing-mode:lr-tb;direction:ltr;white-space:pre-wrap;shape-inside:url(#rect30);display:inline;fill:#3498db;fill-opacity:1;stroke:none;stroke-width:0.787649;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+           x="53.788872"
+           y="225.38052"
+           id="text32"><tspan
+             x="263.0884"
+             y="134.40508"
+             id="tspan15">ITEM</tspan></text>
+      </g>
+      <g
+         id="g34"
+         transform="matrix(0.78146366,0,0,1,116.65056,-23.535636)"
+         style="stroke:#3498db;stroke-width:1.13122;stroke-opacity:1">
+        <rect
+           style="fill:none;stroke:#3498db;stroke-width:0.79751;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+           id="rect32"
+           width="18.863583"
+           height="17.585871"
+           x="257.56424"
+           y="131.6265"
+           rx="3.5321195"
+           ry="2.7602232" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.175px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';text-align:center;writing-mode:lr-tb;direction:ltr;white-space:pre-wrap;shape-inside:url(#rect32);display:inline;fill:#3498db;fill-opacity:1;stroke:none;stroke-width:0.79751;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+           x="53.788872"
+           y="225.38052"
+           id="text34"><tspan
+             x="263.0884"
+             y="134.40508"
+             id="tspan16">ITEM</tspan></text>
+      </g>
+      <path
+         style="fill:#87de87;stroke:#cccccc;stroke-width:0.3;stroke-linecap:round;stroke-dasharray:0.899999, 0.899999;stroke-dashoffset:0"
+         d="M 272.65509,79.651804 V 154.12247"
+         id="path12" />
+      <g
+         id="g78"
+         transform="matrix(0.80115102,0,0,1,96.467219,-23.535636)"
+         style="stroke:#3498db;stroke-width:1.11723;stroke-opacity:1">
+        <rect
+           style="fill:none;stroke:#3498db;stroke-width:0.787649;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+           id="rect76"
+           width="18.863583"
+           height="17.585871"
+           x="257.56424"
+           y="131.6265"
+           rx="3.4453218"
+           ry="2.7602232" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.175px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';text-align:center;writing-mode:lr-tb;direction:ltr;white-space:pre-wrap;shape-inside:url(#rect76);display:inline;fill:#3498db;fill-opacity:1;stroke:none;stroke-width:0.787649;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+           x="53.788872"
+           y="225.38052"
+           id="text78"><tspan
+             x="263.0884"
+             y="134.40508"
+             id="tspan17">ITEM</tspan></text>
+      </g>
+      <path
+         style="fill:#87de87;stroke:#cccccc;stroke-width:0.3;stroke-linecap:round;stroke-dasharray:0.899999, 0.899999;stroke-dashoffset:0"
+         d="M 302.8368,79.651804 V 154.12247"
+         id="path18" />
+      <path
+         style="fill:#87de87;stroke:#cccccc;stroke-width:0.3;stroke-linecap:round;stroke-dasharray:0.899999, 0.899999;stroke-dashoffset:0"
+         d="M 317.92765,79.651804 V 154.12247"
+         id="path19" />
+      <path
+         style="fill:#87de87;stroke:#cccccc;stroke-width:0.3;stroke-linecap:round;stroke-dasharray:0.899999, 0.899999;stroke-dashoffset:0"
+         d="M 287.74594,79.651804 V 154.12247"
+         id="path73" />
+    </g>
+  </g>
+</svg>

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -27,7 +27,7 @@ autoclass_content = "both"
 html_theme = "sphinx_rtd_theme"
 html_static_path = ["_static"]
 html_sidebars = {
-    "**": ["globaltoc.html", "localtoc.html", "relations.html", "searchbox.html"]
+    "**": ["globaltoc.html", "relations.html", "searchbox.html"],
 }  # Displays the global TOC in the sidebar
 html_theme_options = {
     "collapse_navigation": False,

--- a/docs/source/coreapi_introduction.rst
+++ b/docs/source/coreapi_introduction.rst
@@ -9,9 +9,6 @@ The audio data is decoupled from audio files: audio data can be fetched across m
 The ``Core API`` provides ways of computing and plotting spectrograms, which are also treated as time-bound data that can be joined with
 audio (or any other type of) data.
 
-To learn more about the ideas behind the ``Core API``, please visit the :ref:`Introduction to the Core API <coreapi_introduction>` section.
-
-
 Event
 """""
 
@@ -32,7 +29,7 @@ nor if it contains empty time periods between files.
 
 To do so, **OSEkit** uses an intermediary object between the ``Data`` and the ``File``: an ``Item``, which is a **part** of ``Data`` that is found in a **single** ``File``.
 
-As an example, let's consider 3 files that differ in duration (along the x-axis in the figure here below).
+As an example, let's consider 3 files that differ in duration (along the x-axis in the figures here below).
 The first two files are consecutive, and the third one is separated from the end of the second by a duration for which there is no data.
 
 From these 3 files, the user want to manipulate 2 data objects (for example to plot spectrograms from audio files at these 2 time periods):
@@ -51,8 +48,8 @@ Since **OSEkit** provides ways to manipulate different types of data (audio, spe
 are managed in bases classes:
 
 - :class:`OSmOSE.core_api.base_file.BaseFile` represent any **file**
-- :class:`OSmOSE.core_api.base_file.BaseItem` represent any **item**
-- :class:`OSmOSE.core_api.base_file.BaseData` represent any **data**
+- :class:`OSmOSE.core_api.base_item.BaseItem` represent any **item**
+- :class:`OSmOSE.core_api.base_data.BaseData` represent any **data**
 
-These base classes are then derived through inheritance to specialized class for any data type. For example, **audio data** is manipulated through the
+These base classes are then derived through inheritance to specialized classes for any data type. For example, **audio data** is manipulated through the
 :class:`OSmOSE.core_api.audio_data.AudioData` class.

--- a/docs/source/coreapi_usage.rst
+++ b/docs/source/coreapi_usage.rst
@@ -6,4 +6,95 @@ Core API Usage
 Audio File
 ^^^^^^^^^^
 
-To turn an audio file into an **OSEkit**
+To turn an audio file into an **OSEkit** ``AudioFile`` (represented by the :class:`OSmOSE.core_api.audio_file.AudioFile` class), all you need is the path to the file and a begin timestamp.
+
+Such begin timestamp can either be specified (as a :class:`pandas.Timestamp` instance), or parsed from the audio file name by specifing the `strptime format <https://strftime.org/>`_:
+
+.. code-block:: python
+
+    from OSmOSE.core_api.audio_file import AudioFile
+    from pathlib import Path
+
+    af = AudioFile(
+        path = Path(r"foo/7189.230405154906.wav"),
+        strptime_format = "%y%m%d%H%M%S",
+        )
+
+Audio Data
+^^^^^^^^^^
+
+The :class:`OSmOSE.core_api.audio_data.AudioData` class represent a chunk of audio taken between two specific timestamps from one or more `AudioFile` instances.
+
+This class offers means of easily resample the data and access it on-demand (with an optimized I/O workflow to minimize the file openings/closings).
+
+To create an ``AudioData`` from ``AudioFiles``, use the :meth:`OSmOSE.core_api.audio_data.AudioData.from_files` class method.
+
+Example for an ``AudioData`` representing the first 2 seconds of the ``foo/7189.230405154906.wav`` audio file:
+
+.. code-block:: python
+
+    from pandas import Timestamp, Timedelta
+    from OSmOSE.core_api.audio_data import AudioData
+
+    ad = AudioData.from_files(
+    files=[af],
+    end=af.begin + Timedelta(seconds=2) # begin and end defaults to the files boundaries: this will take the 2 first seconds of the audio file.
+    )
+
+This will lead to the following *data* <-> *file* structure (see the :ref:`Data and Files <data_files>` section):
+
+.. image:: _static/audio_data/ex1.svg
+
+If the ``AudioData`` begin and end timestamps cover multiple ``AudioFile``, the corresponding ``AudioItem``.
+
+For example, the `foo` folder here below contains 4 ``10 s``-long files, with a ``10 s`` gap between the 3rd and 4th files:
+
+.. code-block::
+
+    foo
+    ├── 7189.230405154906.wav
+    ├── 7189.230405154916.wav
+    ├── 7189.230405154926.wav
+    └── 7189.230405154946.wav
+
+Let's create a single ``AudioData`` that covers the total duration of the 4 files:
+
+.. code-block:: python
+
+    afs = [
+        AudioFile(f, strptime_format="%y%m%d%H%M%S")
+        for f in foo.glob("*.wav")
+        ]
+
+    ad = AudioData.from_files(files=afs) # begin and end to default will cover the whole duration of the files
+
+This will create one ``AudioItem`` per file, plus one **empty** ``AudioItem`` for the gap:
+
+.. image:: _static/audio_data/ex2.svg
+
+We can check that with code:
+
+>>> print("\n".join("\n\t".join((f"Item {idx}", f"{f'Begin':<15}{str(item.begin):>20}", f"{f'End':<15}{str(item.end):>20}", f"{f'Is gap':<15}{"YES" if item.is_empty else "NO":>20}")) for idx,item in enumerate(sorted(ad.items, key=lambda i: i.begin))))
+"""
+Item 0
+	Begin           2023-04-05 15:49:06
+	End             2023-04-05 15:49:16
+	Is gap                           NO
+Item 1
+	Begin           2023-04-05 15:49:16
+	End             2023-04-05 15:49:26
+	Is gap                           NO
+Item 2
+	Begin           2023-04-05 15:49:26
+	End             2023-04-05 15:49:36
+	Is gap                           NO
+Item 3
+	Begin           2023-04-05 15:49:36
+	End             2023-04-05 15:49:46
+	Is gap                          YES
+Item 4
+	Begin           2023-04-05 15:49:46
+	End             2023-04-05 15:49:56
+	Is gap                           NO
+"""
+

--- a/src/OSmOSE/core_api/spectro_data.py
+++ b/src/OSmOSE/core_api/spectro_data.py
@@ -43,7 +43,7 @@ class SpectroData(BaseData[SpectroItem, SpectroFile]):
         fft: ShortTimeFFT | None = None,
         db_ref: float | None = None,
         v_lim: tuple[float, float] | None = None,
-        colormap: str = "viridis",
+        colormap: str | None = None,
     ) -> None:
         """Initialize a SpectroData from a list of SpectroItems.
 
@@ -82,7 +82,7 @@ class SpectroData(BaseData[SpectroItem, SpectroFile]):
             if db_ref is None
             else (0.0, 170.0)
         )
-        self.colormap = colormap
+        self.colormap = "viridis" if colormap is None else colormap
 
     @staticmethod
     def get_default_ax() -> plt.Axes:
@@ -225,7 +225,9 @@ class SpectroData(BaseData[SpectroItem, SpectroFile]):
         time = np.arange(sx.shape[1]) * self.duration.total_seconds() / sx.shape[1]
         freq = self.fft.f
 
-        ax.pcolormesh(time, freq, sx, vmin=self._v_lim[0], vmax=self._v_lim[1], cmap=self.colormap)
+        ax.pcolormesh(
+            time, freq, sx, vmin=self._v_lim[0], vmax=self._v_lim[1], cmap=self.colormap
+        )
 
     def to_db(self, sx: np.ndarray) -> np.ndarray:
         """Convert the sx values to dB.
@@ -460,6 +462,7 @@ class SpectroData(BaseData[SpectroItem, SpectroFile]):
         cls,
         data: BaseData,
         fft: ShortTimeFFT,
+        colormap: str | None = None,
     ) -> SpectroData:
         """Return an SpectroData object from a BaseData object.
 
@@ -469,6 +472,8 @@ class SpectroData(BaseData[SpectroItem, SpectroFile]):
             BaseData object to convert to SpectroData.
         fft: ShortTimeFFT
             The ShortTimeFFT used to compute the spectrogram.
+        colormap: str
+            The colormap used to plot the spectrogram.
 
         Returns
         -------
@@ -484,6 +489,7 @@ class SpectroData(BaseData[SpectroItem, SpectroFile]):
             fft=fft,
             db_ref=db_ref,
             v_lim=v_lim,
+            colormap=colormap,
         )
 
     @classmethod
@@ -492,6 +498,7 @@ class SpectroData(BaseData[SpectroItem, SpectroFile]):
         data: AudioData,
         fft: ShortTimeFFT,
         v_lim: tuple[float, float] | None = None,
+        colormap: str | None = None,
     ) -> SpectroData:
         """Instantiate a SpectroData object from a AudioData object.
 
@@ -504,6 +511,8 @@ class SpectroData(BaseData[SpectroItem, SpectroFile]):
         v_lim: tuple[float,float]
             Lower and upper limits (in dB) of the colormap used
             for plotting the spectrogram.
+        colormap: str
+            Colormap to use for plotting the spectrogram.
 
         Returns
         -------
@@ -517,6 +526,7 @@ class SpectroData(BaseData[SpectroItem, SpectroFile]):
             begin=data.begin,
             end=data.end,
             v_lim=v_lim,
+            colormap=colormap,
         )
 
     def to_dict(self, embed_sft: bool = True) -> dict:
@@ -559,7 +569,12 @@ class SpectroData(BaseData[SpectroItem, SpectroFile]):
                 else None
             ),
         }
-        return base_dict | audio_dict | sft_dict | {"v_lim": self.v_lim}
+        return (
+            base_dict
+            | audio_dict
+            | sft_dict
+            | {"v_lim": self.v_lim, "colormap": self.colormap}
+        )
 
     @classmethod
     def from_dict(
@@ -591,7 +606,11 @@ class SpectroData(BaseData[SpectroItem, SpectroFile]):
 
         if dictionary["audio_data"] is None:
             base_data = BaseData.from_dict(dictionary)
-            return cls.from_base_data(data=base_data, fft=sft)
+            return cls.from_base_data(
+                data=base_data, fft=sft, colormap=dictionary["colormap"]
+            )
 
         audio_data = AudioData.from_dict(dictionary["audio_data"])
-        return cls.from_audio_data(audio_data, sft, v_lim=dictionary["v_lim"])
+        return cls.from_audio_data(
+            audio_data, sft, v_lim=dictionary["v_lim"], colormap=dictionary["colormap"]
+        )

--- a/src/OSmOSE/core_api/spectro_data.py
+++ b/src/OSmOSE/core_api/spectro_data.py
@@ -43,6 +43,7 @@ class SpectroData(BaseData[SpectroItem, SpectroFile]):
         fft: ShortTimeFFT | None = None,
         db_ref: float | None = None,
         v_lim: tuple[float, float] | None = None,
+        colormap: str = "viridis",
     ) -> None:
         """Initialize a SpectroData from a list of SpectroItems.
 
@@ -65,6 +66,8 @@ class SpectroData(BaseData[SpectroItem, SpectroFile]):
         v_lim: tuple[float,float]
             Lower and upper limits (in dB) of the colormap used
             for plotting the spectrogram.
+        colormap: str
+            Colormap to use for plotting the spectrogram.
 
         """
         super().__init__(items=items, begin=begin, end=end)
@@ -79,6 +82,7 @@ class SpectroData(BaseData[SpectroItem, SpectroFile]):
             if db_ref is None
             else (0.0, 170.0)
         )
+        self.colormap = colormap
 
     @staticmethod
     def get_default_ax() -> plt.Axes:
@@ -221,7 +225,7 @@ class SpectroData(BaseData[SpectroItem, SpectroFile]):
         time = np.arange(sx.shape[1]) * self.duration.total_seconds() / sx.shape[1]
         freq = self.fft.f
 
-        ax.pcolormesh(time, freq, sx, vmin=self._v_lim[0], vmax=self._v_lim[1])
+        ax.pcolormesh(time, freq, sx, vmin=self._v_lim[0], vmax=self._v_lim[1], cmap=self.colormap)
 
     def to_db(self, sx: np.ndarray) -> np.ndarray:
         """Convert the sx values to dB.

--- a/src/OSmOSE/core_api/spectro_dataset.py
+++ b/src/OSmOSE/core_api/spectro_dataset.py
@@ -54,6 +54,19 @@ class SpectroDataset(BaseDataset[SpectroData, SpectroFile]):
             data.fft = fft
 
     @property
+    def colormap(self) -> str:
+        """Return the most frequent colormap of the spectro dataset."""
+        return max(
+            {d.colormap for d in self.data},
+            key=[d.colormap for d in self.data].count,
+        )
+
+    @colormap.setter
+    def colormap(self, colormap: str) -> None:
+        for d in self.data:
+            d.colormap = colormap
+
+    @property
     def folder(self) -> Path:
         """Folder in which the dataset files are located."""
         return self._folder if self._folder is not None else super().folder
@@ -343,10 +356,14 @@ class SpectroDataset(BaseDataset[SpectroData, SpectroFile]):
         base_dataset: BaseDataset,
         fft: ShortTimeFFT,
         name: str | None = None,
+        colormap: str | None = None,
     ) -> SpectroDataset:
         """Return a SpectroDataset object from a BaseDataset object."""
         return cls(
-            [SpectroData.from_base_data(data, fft) for data in base_dataset.data],
+            [
+                SpectroData.from_base_data(data=data, fft=fft, colormap=colormap)
+                for data in base_dataset.data
+            ],
             name=name,
         )
 
@@ -356,6 +373,7 @@ class SpectroDataset(BaseDataset[SpectroData, SpectroFile]):
         audio_dataset: AudioDataset,
         fft: ShortTimeFFT,
         name: str | None = None,
+        colormap: str | None = None,
         v_lim: tuple[float, float] | None = None,
     ) -> SpectroDataset:
         """Return a SpectroDataset object from an AudioDataset object.
@@ -364,7 +382,12 @@ class SpectroDataset(BaseDataset[SpectroData, SpectroFile]):
         """
         return cls(
             data=[
-                SpectroData.from_audio_data(data=d, fft=fft, v_lim=v_lim)
+                SpectroData.from_audio_data(
+                    data=d,
+                    fft=fft,
+                    v_lim=v_lim,
+                    colormap=colormap,
+                )
                 for d in audio_dataset.data
             ],
             name=name,

--- a/src/OSmOSE/public_api/analysis.py
+++ b/src/OSmOSE/public_api/analysis.py
@@ -66,6 +66,7 @@ class Analysis:
         subtype: str | None = None,
         fft: ShortTimeFFT | None = None,
         v_lim: tuple[float, float] | None = None,
+        colormap: str | None = None,
     ) -> None:
         """Initialize an Analysis object.
 
@@ -106,6 +107,9 @@ class Analysis:
         v_lim: tuple[float, float] | None
             Limits (in dB) of the colormap used for plotting the spectrogram.
             Has no effect if Analysis.SPECTROGRAM is not in analysis.
+        colormap: str | None
+            Colormap to use for plotting the spectrogram.
+            Has no effect if Analysis.SPECTROGRAM is not in analysis.
 
         """
         self.analysis_type = analysis_type
@@ -117,6 +121,7 @@ class Analysis:
         self.subtype = subtype
         self.fft = fft
         self.v_lim = v_lim
+        self.colormap = colormap
 
         if self.is_spectro and fft is None:
             raise ValueError(

--- a/src/OSmOSE/public_api/dataset.py
+++ b/src/OSmOSE/public_api/dataset.py
@@ -223,6 +223,7 @@ class Dataset:
             fft=analysis.fft,
             name=ads.base_name,
             v_lim=analysis.v_lim,
+            colormap=analysis.colormap,
         )
 
     def run_analysis(

--- a/src/OSmOSE/public_api/dataset.py
+++ b/src/OSmOSE/public_api/dataset.py
@@ -366,8 +366,8 @@ class Dataset:
                 script_path=export_analysis.__file__,
                 script_args=f"--dataset-json-path {self.folder / 'dataset.json'} "
                 f"--analysis {analysis_type.value} "
-                f"--ads-name {ads.name if ads is not None else ''} "
-                f"--sds-name {sds.name if sds is not None else ''} "
+                f"--ads-name {ads.name if ads is not None else 'None'} "
+                f"--sds-name {sds.name if sds is not None else 'None'} "
                 f"--subtype {subtype} "
                 f"--matrix-folder-name {matrix_folder_name} "
                 f"--spectrogram-folder-name {spectrogram_folder_name} "

--- a/src/OSmOSE/public_api/export_analysis.py
+++ b/src/OSmOSE/public_api/export_analysis.py
@@ -206,7 +206,7 @@ if __name__ == "__main__":
     dataset = Dataset.from_json(file=Path(args.dataset_json_path))
 
     ads, sds = (
-        dataset.get_dataset(ds_name) if ds_name else None
+        dataset.get_dataset(ds_name) if ds_name.lower() != "none" else None
         for ds_name in (args.ads_name, args.sds_name)
     )
     subtype = None if args.subtype.lower() == "none" else args.subtype


### PR DESCRIPTION
This PR adds the `colormap` property to `SpectroData` objects.

The `SpectroDataset.colormap` property returns the **most frequent** colormap across the data. Setting its value will **assign the colormap to every `SpectroData` within the `SpectroDataset`**

In the Public API, the colormap can be assigned to the `Analysis`:

```py
analysis = Analysis(
    AnalysisType.SPECTROGRAM,
    ...
    colormap = "inferno", # switches from the default viridis colormap to inferno.
)
```