### PR TITLE
Feature/frequency scales

### DIFF
--- a/src/OSmOSE/core_api/frequency_scale.py
+++ b/src/OSmOSE/core_api/frequency_scale.py
@@ -83,6 +83,22 @@ class Scale:
             get_closest_value_index(mapped, original_scale) for mapped in mapped_scale
         ]
 
+    def get_mapped_values(self, original_scale: list[float]) -> list[float]:
+        """Return the closest values of the mapped scale from the original scale.
+
+        Parameters
+        ----------
+        original_scale: list[float]
+            Original scale from which the mapped scale is computed.
+
+        Returns
+        -------
+        list[float]
+            Values from the original scale that are the closest to the mapped scale.
+
+        """
+        return [original_scale[i] for i in self.get_mapped_indexes(original_scale)]
+
     def rescale(
         self, sx_matrix: np.ndarray, original_scale: np.ndarray | list
     ) -> np.ndarray:

--- a/src/OSmOSE/core_api/frequency_scale.py
+++ b/src/OSmOSE/core_api/frequency_scale.py
@@ -71,6 +71,10 @@ class ScalePart:
         start, stop = self.get_indexes(scale_length)
         return list(map(round, self.scale_lambda(self.f_min, self.f_max, stop - start)))
 
+    def to_dict_value(self) -> tuple[float, float, float, float, str]:
+        """Serialize a ScalePart to a dictionary entry."""
+        return self.p_min, self.p_max, self.f_min, self.f_max, self.scale_type
+
     def __eq__(self, other: any) -> bool:
         """Overwrite eq dunder."""
         if type(other) is not ScalePart:
@@ -195,9 +199,9 @@ class Scale:
 
         return sx_matrix[new_scale_indexes]
 
-    def to_dict_value(self) -> list[list]:
+    def to_dict_value(self) -> list[tuple[float, float, float, float, str]]:
         """Serialize a Scale to a dictionary entry."""
-        return [[part.p_min, part.p_max, part.f_min, part.f_max] for part in self.parts]
+        return [part.to_dict_value() for part in self.parts]
 
     @classmethod
     def from_dict_value(cls, dict_value: list[list]) -> Scale:

--- a/src/OSmOSE/core_api/frequency_scale.py
+++ b/src/OSmOSE/core_api/frequency_scale.py
@@ -35,3 +35,25 @@ class ScalePart:
 class Scale:
     def __init__(self, parts: list[ScalePart]):
         self.parts = parts
+
+    def map(self, original_scale_length: int) -> list[float]:
+        """Map a given scale to the custom scale defined by its ScaleParts.
+
+        Parameters
+        ----------
+        original_scale_length: int
+            Length of the original frequency scale.
+
+        Returns
+        -------
+        list[float]
+            Mapped frequency scale.
+            Each ScalePart from the Scale.parts attribute are concatenated
+            to form the returned scale.
+
+        """
+        return [
+            v
+            for scale in sorted(self.parts, key=lambda p: (p.p_min, p.p_max))
+            for v in scale.get_values(original_scale_length)
+        ]

--- a/src/OSmOSE/core_api/frequency_scale.py
+++ b/src/OSmOSE/core_api/frequency_scale.py
@@ -26,6 +26,11 @@ class ScalePart:
         """Return the indexes of the present scale part in the full scale."""
         return int(self.p_min * scale_length), int(self.p_max * scale_length)
 
+    def get_values(self, scale_length: int) -> list[int]:
+        """Return the values of the present scale part in the full scale."""
+        start, stop = self.get_indexes(scale_length)
+        return list(map(round, np.linspace(self.f_min, self.f_max, stop - start)))
+
 
 class Scale:
     def __init__(self, parts: list[ScalePart]):

--- a/src/OSmOSE/core_api/frequency_scale.py
+++ b/src/OSmOSE/core_api/frequency_scale.py
@@ -27,16 +27,39 @@ class ScalePart:
     p_max (in % of the axis), representing f_max
     """
 
-    def __init__(self, p_min: float, p_max: float, f_min: float, f_max: float, type: Literal["lin","log"] = "lin"):
+    def __init__(
+        self,
+        p_min: float,
+        p_max: float,
+        f_min: float,
+        f_max: float,
+        scale_type: Literal["lin", "log"] = "lin",
+    ) -> None:
+        """Initialize a ScalePart.
+
+        Parameters
+        ----------
+        p_min: float
+            Position (in percent) of the bottom of the scale part on the full scale.
+        p_max: float
+            Position (in percent) of the top of the scale part on the full scale.
+        f_min: float
+            Frequency corresponding to the bottom of the scale part.
+        f_max: float
+            Frequency corresponding to the top of the scale part.
+        scale_type: Literal["lin", "log"]
+            Type of the scale, either linear or logarithmic.
+
+        """
         self.p_min = p_min
         self.p_max = p_max
         self.f_min = f_min
         self.f_max = f_max
-        self.type: Literal["lin","log"] = "lin"
+        self.scale_type: Literal["lin", "log"] = scale_type
 
     def get_frequencies(self, nb_points: int) -> list[int]:
         """Return the frequency points of the present scale part."""
-        space = np.linspace(self.f_min, self.f_max, nb_points) if self.type == "lin" else np.logspace(self.f_min, self.f_max, nb_points)
+        space = self.scale_lambda(self.f_min, self.f_max, nb_points)
         return list(map(round, space))
 
     def get_indexes(self, scale_length: int) -> tuple[int, int]:
@@ -46,7 +69,7 @@ class ScalePart:
     def get_values(self, scale_length: int) -> list[int]:
         """Return the values of the present scale part."""
         start, stop = self.get_indexes(scale_length)
-        return list(map(round, np.linspace(self.f_min, self.f_max, stop - start)))
+        return list(map(round, self.scale_lambda(self.f_min, self.f_max, stop - start)))
 
     def __eq__(self, other: any) -> bool:
         """Overwrite eq dunder."""
@@ -57,6 +80,16 @@ class ScalePart:
             and self.p_max == other.p_max
             and self.f_min == other.f_min
             and self.f_max == other.f_max
+            and self.scale_type == other.scale_type
+        )
+
+    @property
+    def scale_lambda(self) -> callable:
+        """Lambda function used to generate either a linear or logarithmic scale."""
+        return lambda start, stop, steps: (
+            np.linspace(start, stop, steps)
+            if self.scale_type == "lin"
+            else np.geomspace(start, stop, steps)
         )
 
 

--- a/src/OSmOSE/core_api/frequency_scale.py
+++ b/src/OSmOSE/core_api/frequency_scale.py
@@ -21,3 +21,12 @@ class ScalePart:
     def get_frequencies(self, nb_points: int) -> list[int]:
         """Return the frequency points of the present scale part."""
         return list(map(round, np.linspace(self.f_min, self.f_max, nb_points)))
+
+    def get_indexes(self, scale_length: int) -> tuple[int, int]:
+        """Return the indexes of the present scale part in the full scale."""
+        return int(self.p_min * scale_length), int(self.p_max * scale_length)
+
+
+class Scale:
+    def __init__(self, parts: list[ScalePart]):
+        self.parts = parts

--- a/src/OSmOSE/core_api/frequency_scale.py
+++ b/src/OSmOSE/core_api/frequency_scale.py
@@ -82,3 +82,28 @@ class Scale:
         return [
             get_closest_value_index(mapped, original_scale) for mapped in mapped_scale
         ]
+
+    def rescale(
+        self, sx_matrix: np.ndarray, original_scale: np.ndarray | list
+    ) -> np.ndarray:
+        """Rescale the given spectrum matrix according to the present scale.
+
+        Parameters
+        ----------
+        sx_matrix: np.ndarray
+            Spectrum matrix.
+        original_scale: np.ndarray
+            Original frequency axis of the spectrum matrix.
+
+        Returns
+        -------
+        np.ndarray
+            Spectrum matrix mapped on the present scale.
+
+        """
+        if type(original_scale) is np.ndarray:
+            original_scale = original_scale.tolist()
+
+        new_scale_indexes = self.get_mapped_indexes(original_scale)
+
+        return sx_matrix[new_scale_indexes]

--- a/src/OSmOSE/core_api/frequency_scale.py
+++ b/src/OSmOSE/core_api/frequency_scale.py
@@ -1,0 +1,23 @@
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass
+class ScalePart:
+    """Represent a part of the frequency scale of a spectrogram.
+
+    The given part goes from:
+    p_min (in % of the axis), representing f_min
+    to:
+    p_max (in % of the axis), representing f_max
+    """
+
+    p_min: float
+    p_max: float
+    f_min: float
+    f_max: float
+
+    def get_frequencies(self, nb_points: int) -> list[int]:
+        """Return the frequency points of the present scale part."""
+        return list(map(round, np.linspace(self.f_min, self.f_max, nb_points)))

--- a/src/OSmOSE/core_api/frequency_scale.py
+++ b/src/OSmOSE/core_api/frequency_scale.py
@@ -2,6 +2,8 @@ from dataclasses import dataclass
 
 import numpy as np
 
+from OSmOSE.utils.core_utils import get_closest_value_index
+
 
 @dataclass
 class ScalePart:
@@ -56,4 +58,27 @@ class Scale:
             v
             for scale in sorted(self.parts, key=lambda p: (p.p_min, p.p_max))
             for v in scale.get_values(original_scale_length)
+        ]
+
+    def get_mapped_indexes(self, original_scale: list[float]) -> list[int]:
+        """Return the indexes of the present scale in the original scale.
+
+        The indexes are those of the closest value from the mapped values
+        in the original scale.
+
+        Parameters
+        ----------
+        original_scale: list[float]
+            Original scale from which the mapped scale is computed.
+
+        Returns
+        -------
+        list[int]
+            Indexes of the closest value from the mapped values in the
+            original scale.
+
+        """
+        mapped_scale = self.map(len(original_scale))
+        return [
+            get_closest_value_index(mapped, original_scale) for mapped in mapped_scale
         ]

--- a/src/OSmOSE/core_api/frequency_scale.py
+++ b/src/OSmOSE/core_api/frequency_scale.py
@@ -1,3 +1,14 @@
+"""Custom frequency scales for plotting spectrograms.
+
+The custom scale is formed from a list of ScaleParts, which assign a
+frequency range to a range on the scale.
+Provided ScaleParts should cover the whole scale (from 0% to 100%).
+
+Such Scale can then be passed to the SpectroData.plot() method for the
+spectrogram to be plotted on a custom frequency scale.
+
+"""
+
 from dataclasses import dataclass
 
 import numpy as np
@@ -35,7 +46,19 @@ class ScalePart:
 
 
 class Scale:
-    def __init__(self, parts: list[ScalePart]):
+    """Class that represent a custom frequency scale for plotting spectrograms.
+
+    The custom scale is formed from a list of ScaleParts, which assign a
+    frequency range to a range on the scale.
+    Provided ScaleParts should cover the whole scale (from 0% to 100%).
+
+    Such Scale can then be passed to the SpectroData.plot() method for the
+    spectrogram to be plotted on a custom frequency scale.
+
+    """
+
+    def __init__(self, parts: list[ScalePart]) -> None:
+        """Initialize a Scale object."""
         self.parts = parts
 
     def map(self, original_scale_length: int) -> list[float]:
@@ -100,7 +123,9 @@ class Scale:
         return [original_scale[i] for i in self.get_mapped_indexes(original_scale)]
 
     def rescale(
-        self, sx_matrix: np.ndarray, original_scale: np.ndarray | list
+        self,
+        sx_matrix: np.ndarray,
+        original_scale: np.ndarray | list,
     ) -> np.ndarray:
         """Rescale the given spectrum matrix according to the present scale.
 

--- a/src/OSmOSE/core_api/frequency_scale.py
+++ b/src/OSmOSE/core_api/frequency_scale.py
@@ -11,14 +11,13 @@ spectrogram to be plotted on a custom frequency scale.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from typing import Literal
 
 import numpy as np
 
 from OSmOSE.utils.core_utils import get_closest_value_index
 
 
-@dataclass
 class ScalePart:
     """Represent a part of the frequency scale of a spectrogram.
 
@@ -28,21 +27,24 @@ class ScalePart:
     p_max (in % of the axis), representing f_max
     """
 
-    p_min: float
-    p_max: float
-    f_min: float
-    f_max: float
+    def __init__(self, p_min: float, p_max: float, f_min: float, f_max: float, type: Literal["lin","log"] = "lin"):
+        self.p_min = p_min
+        self.p_max = p_max
+        self.f_min = f_min
+        self.f_max = f_max
+        self.type: Literal["lin","log"] = "lin"
 
     def get_frequencies(self, nb_points: int) -> list[int]:
         """Return the frequency points of the present scale part."""
-        return list(map(round, np.linspace(self.f_min, self.f_max, nb_points)))
+        space = np.linspace(self.f_min, self.f_max, nb_points) if self.type == "lin" else np.logspace(self.f_min, self.f_max, nb_points)
+        return list(map(round, space))
 
     def get_indexes(self, scale_length: int) -> tuple[int, int]:
         """Return the indexes of the present scale part in the full scale."""
         return int(self.p_min * scale_length), int(self.p_max * scale_length)
 
     def get_values(self, scale_length: int) -> list[int]:
-        """Return the values of the present scale part in the full scale."""
+        """Return the values of the present scale part."""
         start, stop = self.get_indexes(scale_length)
         return list(map(round, np.linspace(self.f_min, self.f_max, stop - start)))
 

--- a/src/OSmOSE/core_api/spectro_data.py
+++ b/src/OSmOSE/core_api/spectro_data.py
@@ -18,6 +18,7 @@ from OSmOSE.config import (
 )
 from OSmOSE.core_api.audio_data import AudioData
 from OSmOSE.core_api.base_data import BaseData
+from OSmOSE.core_api.frequency_scale import Scale
 from OSmOSE.core_api.spectro_file import SpectroFile
 from OSmOSE.core_api.spectro_item import SpectroItem
 
@@ -205,7 +206,12 @@ class SpectroData(BaseData[SpectroItem, SpectroFile]):
 
         return sx
 
-    def plot(self, ax: plt.Axes | None = None, sx: np.ndarray | None = None) -> None:
+    def plot(
+        self,
+        ax: plt.Axes | None = None,
+        sx: np.ndarray | None = None,
+        scale: Scale | None = None,
+    ) -> None:
         """Plot the spectrogram on a specific Axes.
 
         Parameters
@@ -215,6 +221,8 @@ class SpectroData(BaseData[SpectroItem, SpectroFile]):
             Defaulted as the SpectroData.get_default_ax Axes.
         sx: np.ndarray | None
             Spectrogram sx values. Will be computed if not provided.
+        scale: OSmOSE.core_api.frequecy_scale.Scale
+            Custom frequency scale to use for plotting the spectrogram.
 
         """
         ax = ax if ax is not None else SpectroData.get_default_ax()
@@ -224,6 +232,8 @@ class SpectroData(BaseData[SpectroItem, SpectroFile]):
 
         time = np.arange(sx.shape[1]) * self.duration.total_seconds() / sx.shape[1]
         freq = self.fft.f
+
+        sx = sx if scale is None else scale.rescale(sx, freq)
 
         ax.pcolormesh(
             time,

--- a/src/OSmOSE/core_api/spectro_data.py
+++ b/src/OSmOSE/core_api/spectro_data.py
@@ -273,6 +273,7 @@ class SpectroData(BaseData[SpectroItem, SpectroFile]):
         folder: Path,
         ax: plt.Axes | None = None,
         sx: np.ndarray | None = None,
+        scale: Scale | None = None,
     ) -> None:
         """Export the spectrogram as a png image.
 
@@ -285,10 +286,12 @@ class SpectroData(BaseData[SpectroItem, SpectroFile]):
             Defaulted as the SpectroData.get_default_ax Axes.
         sx: np.ndarray | None
             Spectrogram sx values. Will be computed if not provided.
+        scale: OSmOSE.core_api.frequecy_scale.Scale
+            Custom frequency scale to use for plotting the spectrogram.
 
         """
         super().create_directories(path=folder)
-        self.plot(ax, sx)
+        self.plot(ax=ax, sx=sx, scale=scale)
         plt.savefig(f"{folder / str(self)}", bbox_inches="tight", pad_inches=0)
         plt.close()
 

--- a/src/OSmOSE/core_api/spectro_dataset.py
+++ b/src/OSmOSE/core_api/spectro_dataset.py
@@ -40,9 +40,11 @@ class SpectroDataset(BaseDataset[SpectroData, SpectroFile]):
         name: str | None = None,
         suffix: str = "",
         folder: Path | None = None,
+        scale: Scale | None = None,
     ) -> None:
         """Initialize a SpectroDataset."""
         super().__init__(data=data, name=name, suffix=suffix, folder=folder)
+        self.scale = scale
 
     @property
     def fft(self) -> ShortTimeFFT:
@@ -92,7 +94,6 @@ class SpectroDataset(BaseDataset[SpectroData, SpectroFile]):
         folder: Path,
         first: int = 0,
         last: int | None = None,
-        scale: Scale | None = None,
     ) -> None:
         """Export all spectrogram data as png images in the specified folder.
 
@@ -104,14 +105,12 @@ class SpectroDataset(BaseDataset[SpectroData, SpectroFile]):
             Index of the first SpectroData object to export.
         last: int|None
             Index after the last SpectroData object to export.
-        scale: OSmOSE.core_api.frequecy_scale.Scale
-            Custom frequency scale to use for plotting the spectrogram.
 
 
         """
         last = len(self.data) if last is None else last
         for data in self.data[first:last]:
-            data.save_spectrogram(folder, scale=scale)
+            data.save_spectrogram(folder, scale=self.scale)
 
     def save_all(
         self,
@@ -120,7 +119,6 @@ class SpectroDataset(BaseDataset[SpectroData, SpectroFile]):
         link: bool = False,
         first: int = 0,
         last: int | None = None,
-        scale: Scale | None = None,
     ) -> None:
         """Export both Sx matrices as npz files and spectrograms for each data.
 
@@ -138,15 +136,13 @@ class SpectroDataset(BaseDataset[SpectroData, SpectroFile]):
             Index of the first SpectroData object to export.
         last: int|None
             Index after the last SpectroData object to export.
-        scale: OSmOSE.core_api.frequecy_scale.Scale
-            Custom frequency scale to use for plotting the spectrogram.
 
         """
         last = len(self.data) if last is None else last
         for data in self.data[first:last]:
             sx = data.get_value()
             data.write(folder=matrix_folder, sx=sx, link=link)
-            data.save_spectrogram(folder=spectrogram_folder, sx=sx, scale=scale)
+            data.save_spectrogram(folder=spectrogram_folder, sx=sx, scale=self.scale)
 
     def link_audio_dataset(
         self,
@@ -241,6 +237,7 @@ class SpectroDataset(BaseDataset[SpectroData, SpectroFile]):
         return {
             "data": spectro_data_dict,
             "sft": sft_dict,
+            "scale": self.scale.to_dict_value() if self.scale is not None else None,
             "name": self._name,
             "suffix": self.suffix,
             "folder": str(self.folder),
@@ -285,6 +282,7 @@ class SpectroDataset(BaseDataset[SpectroData, SpectroFile]):
             name=dictionary["name"],
             suffix=dictionary["suffix"],
             folder=Path(dictionary["folder"]),
+            scale=Scale.from_dict_value(dictionary["scale"]),
         )
 
     @classmethod
@@ -364,6 +362,7 @@ class SpectroDataset(BaseDataset[SpectroData, SpectroFile]):
         fft: ShortTimeFFT,
         name: str | None = None,
         colormap: str | None = None,
+        scale: Scale | None = None,
     ) -> SpectroDataset:
         """Return a SpectroDataset object from a BaseDataset object."""
         return cls(
@@ -372,6 +371,7 @@ class SpectroDataset(BaseDataset[SpectroData, SpectroFile]):
                 for data in base_dataset.data
             ],
             name=name,
+            scale=scale,
         )
 
     @classmethod
@@ -382,6 +382,7 @@ class SpectroDataset(BaseDataset[SpectroData, SpectroFile]):
         name: str | None = None,
         colormap: str | None = None,
         v_lim: tuple[float, float] | None = None,
+        scale: Scale | None = None,
     ) -> SpectroDataset:
         """Return a SpectroDataset object from an AudioDataset object.
 
@@ -398,6 +399,7 @@ class SpectroDataset(BaseDataset[SpectroData, SpectroFile]):
                 for d in audio_dataset.data
             ],
             name=name,
+            scale=scale,
         )
 
     @classmethod

--- a/src/OSmOSE/core_api/spectro_dataset.py
+++ b/src/OSmOSE/core_api/spectro_dataset.py
@@ -13,6 +13,7 @@ import numpy as np
 from scipy.signal import ShortTimeFFT
 
 from OSmOSE.core_api.base_dataset import BaseDataset
+from OSmOSE.core_api.frequency_scale import Scale
 from OSmOSE.core_api.json_serializer import deserialize_json
 from OSmOSE.core_api.spectro_data import SpectroData
 from OSmOSE.core_api.spectro_file import SpectroFile
@@ -91,6 +92,7 @@ class SpectroDataset(BaseDataset[SpectroData, SpectroFile]):
         folder: Path,
         first: int = 0,
         last: int | None = None,
+        scale: Scale | None = None,
     ) -> None:
         """Export all spectrogram data as png images in the specified folder.
 
@@ -102,12 +104,14 @@ class SpectroDataset(BaseDataset[SpectroData, SpectroFile]):
             Index of the first SpectroData object to export.
         last: int|None
             Index after the last SpectroData object to export.
+        scale: OSmOSE.core_api.frequecy_scale.Scale
+            Custom frequency scale to use for plotting the spectrogram.
 
 
         """
         last = len(self.data) if last is None else last
         for data in self.data[first:last]:
-            data.save_spectrogram(folder)
+            data.save_spectrogram(folder, scale=scale)
 
     def save_all(
         self,
@@ -116,6 +120,7 @@ class SpectroDataset(BaseDataset[SpectroData, SpectroFile]):
         link: bool = False,
         first: int = 0,
         last: int | None = None,
+        scale: Scale | None = None,
     ) -> None:
         """Export both Sx matrices as npz files and spectrograms for each data.
 
@@ -133,13 +138,15 @@ class SpectroDataset(BaseDataset[SpectroData, SpectroFile]):
             Index of the first SpectroData object to export.
         last: int|None
             Index after the last SpectroData object to export.
+        scale: OSmOSE.core_api.frequecy_scale.Scale
+            Custom frequency scale to use for plotting the spectrogram.
 
         """
         last = len(self.data) if last is None else last
         for data in self.data[first:last]:
             sx = data.get_value()
             data.write(folder=matrix_folder, sx=sx, link=link)
-            data.save_spectrogram(folder=spectrogram_folder, sx=sx)
+            data.save_spectrogram(folder=spectrogram_folder, sx=sx, scale=scale)
 
     def link_audio_dataset(
         self,

--- a/src/OSmOSE/core_api/spectro_dataset.py
+++ b/src/OSmOSE/core_api/spectro_dataset.py
@@ -277,12 +277,15 @@ class SpectroDataset(BaseDataset[SpectroData, SpectroFile]):
             )
             for name, params in dictionary["data"].items()
         ]
+        scale = dictionary["scale"]
+        if dictionary["scale"] is not None:
+            scale = Scale.from_dict_value(scale)
         return cls(
             data=sd,
             name=dictionary["name"],
             suffix=dictionary["suffix"],
             folder=Path(dictionary["folder"]),
-            scale=Scale.from_dict_value(dictionary["scale"]),
+            scale=scale,
         )
 
     @classmethod

--- a/src/OSmOSE/public_api/analysis.py
+++ b/src/OSmOSE/public_api/analysis.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from enum import Flag, auto
 from typing import TYPE_CHECKING
 
+from OSmOSE.core_api.frequency_scale import Scale
+
 if TYPE_CHECKING:
     from pandas import Timedelta, Timestamp
     from scipy.signal import ShortTimeFFT
@@ -67,6 +69,7 @@ class Analysis:
         fft: ShortTimeFFT | None = None,
         v_lim: tuple[float, float] | None = None,
         colormap: str | None = None,
+        scale: Scale | None = None,
     ) -> None:
         """Initialize an Analysis object.
 
@@ -110,6 +113,9 @@ class Analysis:
         colormap: str | None
             Colormap to use for plotting the spectrogram.
             Has no effect if Analysis.SPECTROGRAM is not in analysis.
+        scale: OSmOSE.core_api.frequecy_scale.Scale
+            Custom frequency scale to use for plotting the spectrogram.
+            Has no effect if Analysis.SPECTROGRAM is not in analysis.
 
         """
         self.analysis_type = analysis_type
@@ -122,6 +128,7 @@ class Analysis:
         self.fft = fft
         self.v_lim = v_lim
         self.colormap = colormap
+        self.scale = scale
 
         if self.is_spectro and fft is None:
             raise ValueError(

--- a/src/OSmOSE/public_api/dataset.py
+++ b/src/OSmOSE/public_api/dataset.py
@@ -224,6 +224,7 @@ class Dataset:
             name=ads.base_name,
             v_lim=analysis.v_lim,
             colormap=analysis.colormap,
+            scale=analysis.scale,
         )
 
     def run_analysis(

--- a/src/OSmOSE/utils/core_utils.py
+++ b/src/OSmOSE/utils/core_utils.py
@@ -4,6 +4,7 @@ import json
 import os
 import shutil
 import time
+from bisect import bisect
 from importlib.resources import as_file
 from importlib.util import find_spec
 from pathlib import Path
@@ -282,3 +283,28 @@ def locked(lock_file: Path) -> callable:
         return wrapper
 
     return inner
+
+
+def get_closest_value_index(target: float, values: list[float]) -> int:
+    """Get the index of the closest value in a list from a target value.
+
+    Parameters
+    ----------
+    target: float
+        Target value from which the closest value is to be found.
+    values: float
+        List of values in which the closest value from target is
+        to be found.
+
+    Returns
+    -------
+    int
+        Index of the closest value from target in values.
+
+    """
+    closest_upper_index = min(bisect(values, target), len(values) - 1)
+    closest_lower_index = max(0, closest_upper_index - 1)
+    return min(
+        (closest_lower_index, closest_upper_index),
+        key=lambda i: abs(values[i] - target),
+    )

--- a/tests/test_frequency_scales.py
+++ b/tests/test_frequency_scales.py
@@ -29,6 +29,18 @@ from OSmOSE.core_api.frequency_scale import Scale, ScalePart
             [10, 10, 11, 11, 12, 12],
             id="float_frequencies_are_rounded",
         ),
+        pytest.param(
+            ScalePart(
+                p_min=0,
+                p_max=1.0,
+                f_min=1.0,
+                f_max=10.0,
+                scale_type="log",
+            ),
+            10,
+            [1, 1, 2, 2, 3, 4, 5, 6, 8, 10],
+            id="logarithmic_scale",
+        ),
     ],
 )
 def test_frequency_scale_part_get_frequencies(
@@ -142,6 +154,18 @@ def test_frequency_scale_part_get_indexes(
             5,
             [200, 250, 300],
             id="odd_second_half",
+        ),
+        pytest.param(
+            ScalePart(
+                p_min=0,
+                p_max=0.5,
+                f_min=100,
+                f_max=200,
+                scale_type="log",
+            ),
+            10,
+            [100, 119, 141, 168, 200],
+            id="logarithmic_scale",
         ),
     ],
 )
@@ -260,6 +284,52 @@ def test_frequency_scale_part_get_values(
                 4_000,
             ],
             id="non_consecutive_parts",
+        ),
+        pytest.param(
+            Scale(
+                parts=[
+                    ScalePart(
+                        p_min=0,
+                        p_max=0.5,
+                        f_min=1,
+                        f_max=100,
+                        scale_type="log",
+                    ),
+                    ScalePart(
+                        p_min=0.5,
+                        p_max=1.0,
+                        f_min=1000,
+                        f_max=5000,
+                        scale_type="log",
+                    ),
+                ],
+            ),
+            10,
+            [1, 3, 10, 32, 100, 1000, 1495, 2236, 3344, 5000],
+            id="logarithmic_scale",
+        ),
+        pytest.param(
+            Scale(
+                parts=[
+                    ScalePart(
+                        p_min=0,
+                        p_max=0.5,
+                        f_min=1,
+                        f_max=100,
+                        scale_type="log",
+                    ),
+                    ScalePart(
+                        p_min=0.5,
+                        p_max=1.0,
+                        f_min=1000,
+                        f_max=5000,
+                        scale_type="lin",
+                    ),
+                ],
+            ),
+            10,
+            [1, 3, 10, 32, 100, 1000, 2000, 3000, 4000, 5000],
+            id="scale_type_mix",
         ),
     ],
 )
@@ -443,6 +513,12 @@ def test_frequency_scale_rescale(
             id="same_scale",
         ),
         pytest.param(
+            ScalePart(0.0, 1.0, 100, 500, scale_type="log"),
+            ScalePart(0.0, 1.0, 100, 500, scale_type="log"),
+            True,
+            id="same_log_scale",
+        ),
+        pytest.param(
             ScalePart(0.0, 1.0, 100, 500),
             ScalePart(0.0, 1.0, 100.0, 500.0),
             True,
@@ -480,9 +556,15 @@ def test_frequency_scale_rescale(
         ),
         pytest.param(
             ScalePart(0.5, 0.6, 1000.0, 5000.0),
-            ScalePart(0.0, 1.0, 100.0, 500.0),
+            ScalePart(0.0, 1.0, 100.0, 500.0, scale_type="log"),
             False,
             id="all_different",
+        ),
+        pytest.param(
+            ScalePart(0.0, 1.0, 100, 500),
+            ScalePart(0.0, 1.0, 100, 500, scale_type="log"),
+            False,
+            id="different_type",
         ),
     ],
 )
@@ -560,6 +642,22 @@ def test_frequency_scale_part_equality(
             Scale(
                 [
                     ScalePart(0.0, 0.5, 0.0, 1.0),
+                    ScalePart(0.5, 1.0, 1.0, 2.0),
+                ],
+            ),
+            Scale(
+                [
+                    ScalePart(0.0, 0.5, 0.0, 1.0, scale_type="log"),
+                    ScalePart(0.5, 1.0, 1.0, 2.0),
+                ],
+            ),
+            False,
+            id="one_different_type",
+        ),
+        pytest.param(
+            Scale(
+                [
+                    ScalePart(0.0, 0.5, 0.0, 1.0),
                     ScalePart(0.5, 1.0, 10.0, 20.0),
                 ],
             ),
@@ -610,6 +708,14 @@ def test_frequency_scale_equality(scale1: Scale, scale2: Scale, expected: bool) 
                 ],
             ),
             id="three_unordered_parts",
+        ),
+        pytest.param(
+            Scale(
+                [
+                    ScalePart(0.0, 1.0, 0.0, 1.0, scale_type="log"),
+                ],
+            ),
+            id="log_scale",
         ),
     ],
 )

--- a/tests/test_frequency_scales.py
+++ b/tests/test_frequency_scales.py
@@ -9,7 +9,7 @@ from OSmOSE.core_api.frequency_scale import ScalePart
         pytest.param(
             ScalePart(
                 p_min=0,
-                p_max=100,
+                p_max=1.0,
                 f_min=0,
                 f_max=3,
             ),
@@ -20,7 +20,7 @@ from OSmOSE.core_api.frequency_scale import ScalePart
         pytest.param(
             ScalePart(
                 p_min=0,
-                p_max=100,
+                p_max=1.0,
                 f_min=10,
                 f_max=12,
             ),
@@ -31,6 +31,65 @@ from OSmOSE.core_api.frequency_scale import ScalePart
     ],
 )
 def test_frequency_scale_part_get_frequencies(
-    scale_part: ScalePart, nb_points: int, expected: list[int]
+    scale_part: ScalePart,
+    nb_points: int,
+    expected: list[int],
 ) -> None:
     assert list(scale_part.get_frequencies(nb_points)) == expected
+
+
+@pytest.mark.parametrize(
+    ("scale_part", "scale_length", "expected"),
+    [
+        pytest.param(
+            ScalePart(
+                p_min=0,
+                p_max=1.0,
+                f_min=0,
+                f_max=500,
+            ),
+            10,
+            (0, 10),
+            id="full_scale",
+        ),
+        pytest.param(
+            ScalePart(
+                p_min=0,
+                p_max=0.5,
+                f_min=0,
+                f_max=500,
+            ),
+            10,
+            (0, 5),
+            id="first_half",
+        ),
+        pytest.param(
+            ScalePart(
+                p_min=0.5,
+                p_max=1.0,
+                f_min=0,
+                f_max=500,
+            ),
+            10,
+            (5, 10),
+            id="last_half",
+        ),
+        pytest.param(
+            ScalePart(
+                p_min=0.18,
+                p_max=0.38,
+                f_min=0,
+                f_max=500,
+            ),
+            10,
+            (1, 3),
+            id="float_index_to_floor",
+        ),
+    ],
+)
+def test_frequency_scale_part_get_indexes(
+    scale_part: ScalePart,
+    scale_length: int,
+    expected: list[int],
+) -> None:
+    assert scale_part.get_indexes(scale_length) == expected

--- a/tests/test_frequency_scales.py
+++ b/tests/test_frequency_scales.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 
 from OSmOSE.core_api.frequency_scale import Scale, ScalePart
@@ -324,3 +325,53 @@ def test_frequency_scale_mapped_indexes(
     expected: list[int],
 ) -> None:
     assert scale.get_mapped_indexes(original_scale=original_scale) == expected
+
+
+@pytest.mark.parametrize(
+    ("input_matrix", "original_scale", "scale", "expected_matrix"),
+    [
+        pytest.param(
+            np.array([[1, 10, 100], [2, 20, 200], [3, 30, 300], [4, 40, 400]]),
+            [0.0, 1.0, 2.0, 3.0],
+            Scale([ScalePart(0.0, 1.0, 0.0, 3.0)]),
+            np.array([[1, 10, 100], [2, 20, 200], [3, 30, 300], [4, 40, 400]]),
+            id="same_scale",
+        ),
+        pytest.param(
+            np.array([[1, 10, 100], [2, 20, 200], [3, 30, 300], [4, 40, 400]]),
+            [0.0, 1.0, 2.0, 3.0],
+            Scale([ScalePart(0.0, 0.5, 0.0, 1.0), ScalePart(0.5, 1.0, 0.0, 1.0)]),
+            np.array([[1, 10, 100], [2, 20, 200], [1, 10, 100], [2, 20, 200]]),
+            id="repeat_first_half",
+        ),
+        pytest.param(
+            np.array([[1, 10, 100], [2, 20, 200], [3, 30, 300], [4, 40, 400]]),
+            [0.0, 1.0, 2.0, 3.0],
+            Scale([ScalePart(0.0, 0.5, 2.0, 3.0), ScalePart(0.5, 1.0, 0.0, 1.0)]),
+            np.array([[3, 30, 300], [4, 40, 400], [1, 10, 100], [2, 20, 200]]),
+            id="switch_halves",
+        ),
+        pytest.param(
+            np.array([[1, 10, 100], [2, 20, 200], [3, 30, 300], [4, 40, 400]]),
+            [0.0, 1.0, 2.0, 3.0],
+            Scale(
+                [
+                    ScalePart(0.0, 0.25, 3.0, 4.0),
+                    ScalePart(0.25, 0.5, 2.0, 3.0),
+                    ScalePart(0.5, 0.75, 0.0, 1.0),
+                    ScalePart(0.75, 1.0, 1.0, 2.0),
+                ]
+            ),
+            np.array([[4, 40, 400], [3, 30, 300], [1, 10, 100], [2, 20, 200]]),
+            id="four_parts",
+        ),
+    ],
+)
+def test_frequency_scale_rescale(
+    input_matrix: np.ndarray,
+    original_scale: np.ndarray,
+    scale: Scale,
+    expected_matrix: np.ndarray,
+) -> None:
+    scaled_matrix = scale.rescale(input_matrix, original_scale)
+    assert np.array_equal(scaled_matrix, expected_matrix)

--- a/tests/test_frequency_scales.py
+++ b/tests/test_frequency_scales.py
@@ -268,3 +268,59 @@ def test_frequency_scale_map(
     expected: list[float],
 ) -> None:
     assert scale.map(scale_length) == expected
+
+
+@pytest.mark.parametrize(
+    ("scale", "original_scale", "expected"),
+    [
+        pytest.param(
+            Scale(
+                parts=[
+                    ScalePart(p_min=0.0, p_max=1.0, f_min=0, f_max=5.0),
+                ],
+            ),
+            [0.0, 1.0, 2.0, 3.0, 4.0, 5.0],
+            [0, 1, 2, 3, 4, 5],
+            id="same_scale",
+        ),
+        pytest.param(
+            Scale(
+                parts=[
+                    ScalePart(p_min=0.0, p_max=0.5, f_min=0, f_max=2.0),
+                    ScalePart(p_min=0.5, p_max=1.0, f_min=3.0, f_max=5.0),
+                ],
+            ),
+            [0.0, 1.0, 2.0, 3.0, 4.0, 5.0],
+            [0, 1, 2, 3, 4, 5],
+            id="same_scale_in_two_parts",
+        ),
+        pytest.param(
+            Scale(
+                parts=[
+                    ScalePart(p_min=0.0, p_max=0.8, f_min=0, f_max=1.0),
+                    ScalePart(p_min=0.8, p_max=1.0, f_min=8.0, f_max=9.0),
+                ],
+            ),
+            [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0],
+            [0, 0, 0, 0, 1, 1, 1, 1, 8, 9],
+            id="two_different_parts",
+        ),
+        pytest.param(
+            Scale(
+                parts=[
+                    ScalePart(p_min=0.0, p_max=0.8, f_min=100, f_max=110.0),
+                    ScalePart(p_min=0.8, p_max=1.0, f_min=180.0, f_max=190.0),
+                ],
+            ),
+            [100.0, 110.0, 120.0, 130.0, 140.0, 150.0, 160.0, 170.0, 180.0, 190.0],
+            [0, 0, 0, 0, 1, 1, 1, 1, 8, 9],
+            id="different_frequencies_same_indexes",
+        ),
+    ],
+)
+def test_frequency_scale_mapped_indexes(
+    scale: Scale,
+    original_scale: list[float],
+    expected: list[int],
+) -> None:
+    assert scale.get_mapped_indexes(original_scale=original_scale) == expected

--- a/tests/test_frequency_scales.py
+++ b/tests/test_frequency_scales.py
@@ -1,6 +1,6 @@
 import pytest
 
-from OSmOSE.core_api.frequency_scale import ScalePart
+from OSmOSE.core_api.frequency_scale import Scale, ScalePart
 
 
 @pytest.mark.parametrize(
@@ -150,3 +150,121 @@ def test_frequency_scale_part_get_values(
     expected: list[int],
 ) -> None:
     assert scale_part.get_values(nb_points) == expected
+
+
+@pytest.mark.parametrize(
+    ("scale", "scale_length", "expected"),
+    [
+        pytest.param(
+            Scale(
+                parts=[
+                    ScalePart(
+                        p_min=0,
+                        p_max=1.0,
+                        f_min=0,
+                        f_max=3,
+                    ),
+                ],
+            ),
+            4,
+            [0, 1, 2, 3],
+            id="one_full_part",
+        ),
+        pytest.param(
+            Scale(
+                parts=[
+                    ScalePart(
+                        p_min=0,
+                        p_max=0.5,
+                        f_min=0,
+                        f_max=1,
+                    ),
+                    ScalePart(
+                        p_min=0.5,
+                        p_max=1.0,
+                        f_min=2,
+                        f_max=3,
+                    ),
+                ],
+            ),
+            4,
+            [0, 1, 2, 3],
+            id="even_length_cut_in_half",
+        ),
+        pytest.param(
+            Scale(
+                parts=[
+                    ScalePart(
+                        p_min=0,
+                        p_max=0.5,
+                        f_min=0,
+                        f_max=1,
+                    ),
+                    ScalePart(
+                        p_min=0.5,
+                        p_max=1.0,
+                        f_min=2,
+                        f_max=4,
+                    ),
+                ],
+            ),
+            5,
+            [0, 1, 2, 3, 4],
+            id="odd_length_cut_in_half",
+        ),
+        pytest.param(
+            Scale(
+                parts=[
+                    ScalePart(
+                        p_min=0,
+                        p_max=0.1,
+                        f_min=100,
+                        f_max=200,
+                    ),
+                    ScalePart(
+                        p_min=0.1,
+                        p_max=0.5,
+                        f_min=500,
+                        f_max=1_200,
+                    ),
+                    ScalePart(
+                        p_min=0.5,
+                        p_max=1.0,
+                        f_min=3_100,
+                        f_max=4_000,
+                    ),
+                ],
+            ),
+            20,
+            [
+                100,
+                200,
+                500,
+                600,
+                700,
+                800,
+                900,
+                1_000,
+                1_100,
+                1_200,
+                3_100,
+                3_200,
+                3_300,
+                3_400,
+                3_500,
+                3_600,
+                3_700,
+                3_800,
+                3_900,
+                4_000,
+            ],
+            id="non_consecutive_parts",
+        ),
+    ],
+)
+def test_frequency_scale_map(
+    scale: Scale,
+    scale_length: int,
+    expected: list[float],
+) -> None:
+    assert scale.map(scale_length) == expected

--- a/tests/test_frequency_scales.py
+++ b/tests/test_frequency_scales.py
@@ -328,6 +328,62 @@ def test_frequency_scale_mapped_indexes(
 
 
 @pytest.mark.parametrize(
+    ("scale", "original_scale", "expected"),
+    [
+        pytest.param(
+            Scale(
+                parts=[
+                    ScalePart(p_min=0.0, p_max=1.0, f_min=0, f_max=5.0),
+                ],
+            ),
+            [0.0, 1.0, 2.0, 3.0, 4.0, 5.0],
+            [0.0, 1.0, 2.0, 3.0, 4.0, 5.0],
+            id="same_scale",
+        ),
+        pytest.param(
+            Scale(
+                parts=[
+                    ScalePart(p_min=0.0, p_max=0.5, f_min=0, f_max=2.0),
+                    ScalePart(p_min=0.5, p_max=1.0, f_min=3.0, f_max=5.0),
+                ],
+            ),
+            [0.0, 1.0, 2.0, 3.0, 4.0, 5.0],
+            [0.0, 1.0, 2.0, 3.0, 4.0, 5.0],
+            id="same_scale_in_two_parts",
+        ),
+        pytest.param(
+            Scale(
+                parts=[
+                    ScalePart(p_min=0.0, p_max=0.8, f_min=0, f_max=1.0),
+                    ScalePart(p_min=0.8, p_max=1.0, f_min=8.0, f_max=9.0),
+                ],
+            ),
+            [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0],
+            [0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 8.0, 9.0],
+            id="two_different_parts",
+        ),
+        pytest.param(
+            Scale(
+                parts=[
+                    ScalePart(p_min=0.0, p_max=0.8, f_min=100, f_max=110.0),
+                    ScalePart(p_min=0.8, p_max=1.0, f_min=180.0, f_max=190.0),
+                ],
+            ),
+            [100.0, 110.0, 120.0, 130.0, 140.0, 150.0, 160.0, 170.0, 180.0, 190.0],
+            [100.0, 100.0, 100.0, 100.0, 110.0, 110.0, 110.0, 110.0, 180.0, 190.0],
+            id="different_frequencies_same_indexes",
+        ),
+    ],
+)
+def test_frequency_scale_mapped_values(
+    scale: Scale,
+    original_scale: list[float],
+    expected: list[int],
+) -> None:
+    assert scale.get_mapped_values(original_scale=original_scale) == expected
+
+
+@pytest.mark.parametrize(
     ("input_matrix", "original_scale", "scale", "expected_matrix"),
     [
         pytest.param(
@@ -360,7 +416,7 @@ def test_frequency_scale_mapped_indexes(
                     ScalePart(0.25, 0.5, 2.0, 3.0),
                     ScalePart(0.5, 0.75, 0.0, 1.0),
                     ScalePart(0.75, 1.0, 1.0, 2.0),
-                ]
+                ],
             ),
             np.array([[4, 40, 400], [3, 30, 300], [1, 10, 100], [2, 20, 200]]),
             id="four_parts",

--- a/tests/test_frequency_scales.py
+++ b/tests/test_frequency_scales.py
@@ -1,0 +1,36 @@
+import pytest
+
+from OSmOSE.core_api.frequency_scale import ScalePart
+
+
+@pytest.mark.parametrize(
+    ("scale_part", "nb_points", "expected"),
+    [
+        pytest.param(
+            ScalePart(
+                p_min=0,
+                p_max=100,
+                f_min=0,
+                f_max=3,
+            ),
+            4,
+            [0, 1, 2, 3],
+            id="simple_case",
+        ),
+        pytest.param(
+            ScalePart(
+                p_min=0,
+                p_max=100,
+                f_min=10,
+                f_max=12,
+            ),
+            6,
+            [10, 10, 11, 11, 12, 12],
+            id="float_frequencies_are_rounded",
+        ),
+    ],
+)
+def test_frequency_scale_part_get_frequencies(
+    scale_part: ScalePart, nb_points: int, expected: list[int]
+) -> None:
+    assert list(scale_part.get_frequencies(nb_points)) == expected

--- a/tests/test_frequency_scales.py
+++ b/tests/test_frequency_scales.py
@@ -93,3 +93,60 @@ def test_frequency_scale_part_get_indexes(
     expected: list[int],
 ) -> None:
     assert scale_part.get_indexes(scale_length) == expected
+
+
+@pytest.mark.parametrize(
+    ("scale_part", "nb_points", "expected"),
+    [
+        pytest.param(
+            ScalePart(
+                p_min=0,
+                p_max=1.0,
+                f_min=0,
+                f_max=3,
+            ),
+            4,
+            [0, 1, 2, 3],
+            id="full_scale",
+        ),
+        pytest.param(
+            ScalePart(
+                p_min=0,
+                p_max=1.0,
+                f_min=100,
+                f_max=200,
+            ),
+            5,
+            [100, 125, 150, 175, 200],
+            id="full_scale_large_frequencies",
+        ),
+        pytest.param(
+            ScalePart(
+                p_min=0.0,
+                p_max=0.5,
+                f_min=100,
+                f_max=200,
+            ),
+            5,
+            [100, 200],
+            id="odd_first_half",
+        ),
+        pytest.param(
+            ScalePart(
+                p_min=0.5,
+                p_max=1.0,
+                f_min=200,
+                f_max=300,
+            ),
+            5,
+            [200, 250, 300],
+            id="odd_second_half",
+        ),
+    ],
+)
+def test_frequency_scale_part_get_values(
+    scale_part: ScalePart,
+    nb_points: int,
+    expected: list[int],
+) -> None:
+    assert scale_part.get_values(nb_points) == expected

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -14,6 +14,7 @@ from OSmOSE.config import (
 )
 from OSmOSE.core_api.audio_dataset import AudioDataset
 from OSmOSE.core_api.event import Event
+from OSmOSE.core_api.frequency_scale import Scale, ScalePart
 from OSmOSE.core_api.instrument import Instrument
 from OSmOSE.core_api.spectro_dataset import SpectroDataset
 from OSmOSE.public_api.analysis import Analysis, AnalysisType
@@ -970,6 +971,12 @@ def test_get_analysis_audiodataset(
                 sample_rate=24_000,
                 subtype="DOUBLE",
                 fft=ShortTimeFFT(hamming(1024), 512, 24_000),
+                scale=Scale(
+                    [
+                        ScalePart(0.0, 0.5, 0.0, 24_000, "lin"),
+                        ScalePart(0.0, 0.5, 1000.0, 24_000, "log"),
+                    ]
+                ),
             ),
             [
                 Event(
@@ -1024,6 +1031,7 @@ def test_get_analysis_spectrodataset(
     assert analysis_sds.data[0].audio_data.instrument is dataset.instrument
 
     assert analysis_sds.fft is analysis.fft
+    assert analysis_sds.scale is analysis.scale
 
 
 def test_edit_analysis_before_run(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,6 +8,7 @@ import pytest
 
 from OSmOSE.utils.core_utils import (
     file_indexes_per_batch,
+    get_closest_value_index,
     locked,
     nb_files_per_batch,
 )
@@ -315,3 +316,44 @@ def test_locked(tmp_path: pytest.fixture, monkeypatch: pytest.MonkeyPatch) -> No
     lock_file.touch()
     with pytest.raises(PermissionError, match="Lock file present.") as e:
         assert edit_file("") == e
+
+
+@pytest.mark.parametrize(
+    ("values", "target", "expected"),
+    [
+        pytest.param(
+            list(range(10)),
+            5,
+            5,
+            id="target_is_in_values",
+        ),
+        pytest.param(
+            list(range(10)),
+            5.2,
+            5,
+            id="target_is_closer_to_floor",
+        ),
+        pytest.param(
+            list(range(10)),
+            5.6,
+            6,
+            id="target_is_closer_to_ceiling",
+        ),
+        pytest.param(
+            list(range(10, 20)),
+            5,
+            0,
+            id="target_is_smaller_than_first_item",
+        ),
+        pytest.param(
+            list(range(10, 20)),
+            30,
+            9,
+            id="target_is_greater_than_last_item",
+        ),
+    ],
+)
+def test_get_closest_value_index(
+    values: list[float], target: float, expected: int
+) -> None:
+    assert get_closest_value_index(values=values, target=target) == expected


### PR DESCRIPTION
# 🐳Custom frequency scales

## 🐳Introduction

This PR introduces a way of setting up the y-axis of the computed spectrograms. This frequency scale can be split in parts at will, allowing e.g. to plot linear low frequency content in the 1rst third of the scale, and logarithmic high-frequency content on the 2 upper thirds of the scale.

## 🐳Usage

The `OSmOSE.core_api.frequency_scale` module allows to instantiate the `Scale` class, that is passed to the `SpectroData.plot()` method to manipulate the frequency scale:

```py
from OSmOSE.core_api.frequency_scale import Scale, ScalePart

scale = Scale(
    [
        ScalePart(p_min=0.,p_max=0.33,f_min=5_000,f_max=20_000., scale_type="lin"),
        ScalePart(p_min=0.33,p_max=1.,f_min=2_000.,f_max=30_000.,scale_type="log"),
    ]
)

sd.plot(scale=scale) # sd is a SpectroData instance
```

In the resulting spectrogram:

- The first third of the y axis (going from `p_min = 0%` to `p_max = 33%` of the total scale length) is a linear scale ranging from `f_min = 5_000 Hz` to `f_max=20_000 Hz`.
- The remaining top of the y axis (going from `p_min = 33%` to `p_max = 100%` of the total scale length) is a logarithmic scale ranging from `f_min = 2_000 Hz` to `f_max=30_000 Hz`.

![image](https://github.com/user-attachments/assets/cea5f86d-65a8-4176-bd83-27b5e3664e04)

The `SpectroDataset` class now has a `scale` field, which will apply the provided scale to each `SpectroData` on `SpectroDataset.save_spectrogram` and `SpectroDataset.save_all` calls. 

## 🐳Using the `Scale` in the Public API

In the public API, a `Scale` instance can simply be passed to the `Analysis` constructor:

```py
analysis = Analysis(
    AnalysisType.SPECTROGRAM,
    ...
    scale=Scale(...)
)

dataset.run(analysis) # The exported spectrograms will be plotted according to the custom Scale.
```