### PR TITLE
SpectroDataset v_lim

### DIFF
--- a/src/OSmOSE/core_api/spectro_data.py
+++ b/src/OSmOSE/core_api/spectro_data.py
@@ -631,7 +631,7 @@ class SpectroData(BaseData[SpectroItem, SpectroFile]):
         spectro_data = cls.from_audio_data(
             audio_data,
             sft,
-            v_lim=dictionary["v_lim"],
+            v_lim=tuple(dictionary["v_lim"]),
             colormap=dictionary["colormap"],
         )
 

--- a/src/OSmOSE/core_api/spectro_data.py
+++ b/src/OSmOSE/core_api/spectro_data.py
@@ -76,13 +76,7 @@ class SpectroData(BaseData[SpectroItem, SpectroFile]):
         self.fft = fft
         self._sx_dtype = complex
         self._db_ref = db_ref
-        self._v_lim = (
-            v_lim
-            if v_lim is not None
-            else (-120.0, 0.0)
-            if db_ref is None
-            else (0.0, 170.0)
-        )
+        self.v_lim = v_lim
         self.colormap = "viridis" if colormap is None else colormap
 
     @staticmethod
@@ -179,7 +173,14 @@ class SpectroData(BaseData[SpectroItem, SpectroFile]):
         return self._v_lim
 
     @v_lim.setter
-    def v_lim(self, v_lim: tuple[float, float]) -> None:
+    def v_lim(self, v_lim: tuple[float, float] | None) -> None:
+        v_lim = (
+            v_lim
+            if v_lim is not None
+            else (-120.0, 0.0)
+            if self.db_ref is None
+            else (0.0, 170.0)
+        )
         self._v_lim = v_lim
 
     def __str__(self) -> str:

--- a/src/OSmOSE/core_api/spectro_dataset.py
+++ b/src/OSmOSE/core_api/spectro_dataset.py
@@ -41,10 +41,12 @@ class SpectroDataset(BaseDataset[SpectroData, SpectroFile]):
         suffix: str = "",
         folder: Path | None = None,
         scale: Scale | None = None,
+        v_lim: tuple[float, float] | None = None,
     ) -> None:
         """Initialize a SpectroDataset."""
         super().__init__(data=data, name=name, suffix=suffix, folder=folder)
         self.scale = scale
+        self.v_lim = v_lim
 
     @property
     def fft(self) -> ShortTimeFFT:
@@ -68,6 +70,19 @@ class SpectroDataset(BaseDataset[SpectroData, SpectroFile]):
     def colormap(self, colormap: str) -> None:
         for d in self.data:
             d.colormap = colormap
+
+    @property
+    def v_lim(self) -> tuple[float, float] | None:
+        """Return the most frequent colormap of the spectro dataset."""
+        return max(
+            {d.v_lim for d in self.data},
+            key=[d.v_lim for d in self.data].count,
+        )
+
+    @v_lim.setter
+    def v_lim(self, v_lim: tuple[float, float] | None) -> None:
+        for d in self.data:
+            d.v_lim = v_lim
 
     @property
     def folder(self) -> Path:

--- a/src/OSmOSE/core_api/spectro_dataset.py
+++ b/src/OSmOSE/core_api/spectro_dataset.py
@@ -73,7 +73,7 @@ class SpectroDataset(BaseDataset[SpectroData, SpectroFile]):
 
     @property
     def v_lim(self) -> tuple[float, float] | None:
-        """Return the most frequent colormap of the spectro dataset."""
+        """Return the most frequent v_lim of the spectro dataset."""
         return max(
             {d.v_lim for d in self.data},
             key=[d.v_lim for d in self.data].count,
@@ -81,6 +81,14 @@ class SpectroDataset(BaseDataset[SpectroData, SpectroFile]):
 
     @v_lim.setter
     def v_lim(self, v_lim: tuple[float, float] | None) -> None:
+        """Set the spectrogram color scale limits (in dB).
+
+        Parameters
+        ----------
+        v_lim: tuple[float, float] | None
+            Limits (in dB) of the colormap used for plotting the spectrogram.
+
+        """
         for d in self.data:
             d.v_lim = v_lim
 
@@ -314,6 +322,7 @@ class SpectroDataset(BaseDataset[SpectroData, SpectroFile]):
         bound: Literal["files", "timedelta"] = "timedelta",
         data_duration: Timedelta | None = None,
         name: str | None = None,
+        v_lim: tuple[float, float] | None = None,
         **kwargs: any,
     ) -> SpectroDataset:
         """Return a SpectroDataset from a folder containing the spectro files.
@@ -348,6 +357,8 @@ class SpectroDataset(BaseDataset[SpectroData, SpectroFile]):
             Else, one data object will cover the whole time period.
         name: str|None
             Name of the dataset.
+        v_lim: tuple[float, float] | None
+            Limits (in dB) of the colormap used for plotting the spectrogram.
         kwargs: any
             Keyword arguments passed to the BaseDataset.from_folder classmethod.
 
@@ -371,7 +382,9 @@ class SpectroDataset(BaseDataset[SpectroData, SpectroFile]):
             **kwargs,
         )
         sft = next(iter(base_dataset.files)).get_fft()
-        return cls.from_base_dataset(base_dataset=base_dataset, fft=sft, name=name)
+        return cls.from_base_dataset(
+            base_dataset=base_dataset, fft=sft, name=name, v_lim=v_lim
+        )
 
     @classmethod
     def from_base_dataset(
@@ -381,6 +394,7 @@ class SpectroDataset(BaseDataset[SpectroData, SpectroFile]):
         name: str | None = None,
         colormap: str | None = None,
         scale: Scale | None = None,
+        v_lim: tuple[float, float] | None = None,
     ) -> SpectroDataset:
         """Return a SpectroDataset object from a BaseDataset object."""
         return cls(
@@ -390,6 +404,7 @@ class SpectroDataset(BaseDataset[SpectroData, SpectroFile]):
             ],
             name=name,
             scale=scale,
+            v_lim=v_lim,
         )
 
     @classmethod
@@ -411,13 +426,13 @@ class SpectroDataset(BaseDataset[SpectroData, SpectroFile]):
                 SpectroData.from_audio_data(
                     data=d,
                     fft=fft,
-                    v_lim=v_lim,
                     colormap=colormap,
                 )
                 for d in audio_dataset.data
             ],
             name=name,
             scale=scale,
+            v_lim=v_lim,
         )
 
     @classmethod

--- a/src/OSmOSE/core_api/spectro_dataset.py
+++ b/src/OSmOSE/core_api/spectro_dataset.py
@@ -34,6 +34,8 @@ class SpectroDataset(BaseDataset[SpectroData, SpectroFile]):
 
     """
 
+    sentinel_value = object()
+
     def __init__(
         self,
         data: list[SpectroData],
@@ -41,12 +43,17 @@ class SpectroDataset(BaseDataset[SpectroData, SpectroFile]):
         suffix: str = "",
         folder: Path | None = None,
         scale: Scale | None = None,
-        v_lim: tuple[float, float] | None = None,
+        v_lim: tuple[float, float] | None | object = sentinel_value,
     ) -> None:
         """Initialize a SpectroDataset."""
         super().__init__(data=data, name=name, suffix=suffix, folder=folder)
         self.scale = scale
-        self.v_lim = v_lim
+
+        if v_lim is not self.sentinel_value:
+            # the sentinel value allows to differentiate between
+            # a specified None value (resets the v_lim to the default values)
+            # from an unspecified v_lim (in that case, the data v_lim are unchanged)
+            self.v_lim = v_lim
 
     @property
     def fft(self) -> ShortTimeFFT:
@@ -322,7 +329,7 @@ class SpectroDataset(BaseDataset[SpectroData, SpectroFile]):
         bound: Literal["files", "timedelta"] = "timedelta",
         data_duration: Timedelta | None = None,
         name: str | None = None,
-        v_lim: tuple[float, float] | None = None,
+        v_lim: tuple[float, float] | None | object = sentinel_value,
         **kwargs: any,
     ) -> SpectroDataset:
         """Return a SpectroDataset from a folder containing the spectro files.
@@ -383,7 +390,10 @@ class SpectroDataset(BaseDataset[SpectroData, SpectroFile]):
         )
         sft = next(iter(base_dataset.files)).get_fft()
         return cls.from_base_dataset(
-            base_dataset=base_dataset, fft=sft, name=name, v_lim=v_lim
+            base_dataset=base_dataset,
+            fft=sft,
+            name=name,
+            v_lim=v_lim,
         )
 
     @classmethod
@@ -394,7 +404,7 @@ class SpectroDataset(BaseDataset[SpectroData, SpectroFile]):
         name: str | None = None,
         colormap: str | None = None,
         scale: Scale | None = None,
-        v_lim: tuple[float, float] | None = None,
+        v_lim: tuple[float, float] | None | object = sentinel_value,
     ) -> SpectroDataset:
         """Return a SpectroDataset object from a BaseDataset object."""
         return cls(
@@ -414,7 +424,7 @@ class SpectroDataset(BaseDataset[SpectroData, SpectroFile]):
         fft: ShortTimeFFT,
         name: str | None = None,
         colormap: str | None = None,
-        v_lim: tuple[float, float] | None = None,
+        v_lim: tuple[float, float] | None = sentinel_value,
         scale: Scale | None = None,
     ) -> SpectroDataset:
         """Return a SpectroDataset object from an AudioDataset object.

--- a/src/OSmOSE/core_api/spectro_dataset.py
+++ b/src/OSmOSE/core_api/spectro_dataset.py
@@ -34,7 +34,7 @@ class SpectroDataset(BaseDataset[SpectroData, SpectroFile]):
 
     """
 
-    sentinel_value = object()
+    __sentinel_value = object()
 
     def __init__(
         self,
@@ -43,13 +43,13 @@ class SpectroDataset(BaseDataset[SpectroData, SpectroFile]):
         suffix: str = "",
         folder: Path | None = None,
         scale: Scale | None = None,
-        v_lim: tuple[float, float] | None | object = sentinel_value,
+        v_lim: tuple[float, float] | None | object = __sentinel_value,
     ) -> None:
         """Initialize a SpectroDataset."""
         super().__init__(data=data, name=name, suffix=suffix, folder=folder)
         self.scale = scale
 
-        if v_lim is not self.sentinel_value:
+        if v_lim is not self.__sentinel_value:
             # the sentinel value allows to differentiate between
             # a specified None value (resets the v_lim to the default values)
             # from an unspecified v_lim (in that case, the data v_lim are unchanged)
@@ -329,7 +329,7 @@ class SpectroDataset(BaseDataset[SpectroData, SpectroFile]):
         bound: Literal["files", "timedelta"] = "timedelta",
         data_duration: Timedelta | None = None,
         name: str | None = None,
-        v_lim: tuple[float, float] | None | object = sentinel_value,
+        v_lim: tuple[float, float] | None | object = __sentinel_value,
         **kwargs: any,
     ) -> SpectroDataset:
         """Return a SpectroDataset from a folder containing the spectro files.
@@ -404,7 +404,7 @@ class SpectroDataset(BaseDataset[SpectroData, SpectroFile]):
         name: str | None = None,
         colormap: str | None = None,
         scale: Scale | None = None,
-        v_lim: tuple[float, float] | None | object = sentinel_value,
+        v_lim: tuple[float, float] | None | object = __sentinel_value,
     ) -> SpectroDataset:
         """Return a SpectroDataset object from a BaseDataset object."""
         return cls(
@@ -424,7 +424,7 @@ class SpectroDataset(BaseDataset[SpectroData, SpectroFile]):
         fft: ShortTimeFFT,
         name: str | None = None,
         colormap: str | None = None,
-        v_lim: tuple[float, float] | None = sentinel_value,
+        v_lim: tuple[float, float] | None = __sentinel_value,
         scale: Scale | None = None,
     ) -> SpectroDataset:
         """Return a SpectroDataset object from an AudioDataset object.


### PR DESCRIPTION
# 🐳What's new?

This PR simply adds the `SpectroDataset.v_lim` property, which applies the `v_lim` to its data objects.

It adds a sentinel value to the `SpectroDataset` class to check wether `v_lim` has been **set** to None (in which case all data `v_lim` is set to the default value) or if it hasn't been specified (in which case the data v_lim is left untouched).