### PR TITLE
Feature/file start data bind

### DIFF
--- a/docs/source/analysis.rst
+++ b/docs/source/analysis.rst
@@ -3,12 +3,12 @@ Analysis
 
 .. _analysis:
 
-.. autoclass:: OSmOSE.public_api.analysis.Analysis
+.. autoclass:: osekit.public_api.analysis.Analysis
    :members:
 
 ===============
 
 .. _analysis_Type:
 
-.. autoclass:: OSmOSE.public_api.analysis.AnalysisType
+.. autoclass:: osekit.public_api.analysis.AnalysisType
    :members:

--- a/docs/source/audiodata.rst
+++ b/docs/source/audiodata.rst
@@ -3,5 +3,5 @@ AudioData
 
 .. _audiodata:
 
-.. autoclass:: OSmOSE.core_api.audio_data.AudioData
+.. autoclass:: osekit.core_api.audio_data.AudioData
    :members:

--- a/docs/source/audiodataset.rst
+++ b/docs/source/audiodataset.rst
@@ -3,5 +3,5 @@ AudioDataset
 
 .. _audiodataset:
 
-.. autoclass:: OSmOSE.core_api.audio_dataset.AudioDataset
+.. autoclass:: osekit.core_api.audio_dataset.AudioDataset
    :members:

--- a/docs/source/audiofile.rst
+++ b/docs/source/audiofile.rst
@@ -3,5 +3,5 @@ AudioFile
 
 .. _audiofile:
 
-.. autoclass:: OSmOSE.core_api.audio_file.AudioFile
+.. autoclass:: osekit.core_api.audio_file.AudioFile
    :members:

--- a/docs/source/audiofilemanager.rst
+++ b/docs/source/audiofilemanager.rst
@@ -3,5 +3,5 @@ AudioFileManager
 
 .. _audiofilemanager:
 
-.. autoclass:: OSmOSE.core_api.audio_file_manager.AudioFileManager
+.. autoclass:: osekit.core_api.audio_file_manager.AudioFileManager
    :members:

--- a/docs/source/audioitem.rst
+++ b/docs/source/audioitem.rst
@@ -3,5 +3,5 @@ AudioItem
 
 .. _audioitem:
 
-.. autoclass:: OSmOSE.core_api.audio_item.AudioItem
+.. autoclass:: osekit.core_api.audio_item.AudioItem
    :members:

--- a/docs/source/basedata.rst
+++ b/docs/source/basedata.rst
@@ -3,5 +3,5 @@ BaseData
 
 .. _basedata:
 
-.. autoclass:: OSmOSE.core_api.base_data.BaseData
+.. autoclass:: osekit.core_api.base_data.BaseData
    :members:

--- a/docs/source/basedataset.rst
+++ b/docs/source/basedataset.rst
@@ -3,5 +3,5 @@ BaseDataset
 
 .. _basedataset:
 
-.. autoclass:: OSmOSE.core_api.base_dataset.BaseDataset
+.. autoclass:: osekit.core_api.base_dataset.BaseDataset
    :members:

--- a/docs/source/basefile.rst
+++ b/docs/source/basefile.rst
@@ -3,5 +3,5 @@ BaseFile
 
 .. _basefile:
 
-.. autoclass:: OSmOSE.core_api.base_file.BaseFile
+.. autoclass:: osekit.core_api.base_file.BaseFile
    :members:

--- a/docs/source/baseitem.rst
+++ b/docs/source/baseitem.rst
@@ -3,5 +3,5 @@ BaseItem
 
 .. _baseitem:
 
-.. autoclass:: OSmOSE.core_api.base_item.BaseItem
+.. autoclass:: osekit.core_api.base_item.BaseItem
    :members:

--- a/docs/source/coreapi_introduction.rst
+++ b/docs/source/coreapi_introduction.rst
@@ -14,7 +14,7 @@ Event
 
 .. _event:
 
-The :class:`OSmOSE.core_api.event.Event` represent anything that is time-bound: an ``Event`` has a begin and an end, which are described as `pandas Timestamps <https://pandas.pydata.org/docs/reference/api/pandas.Timestamp.html>`_.
+The :class:`osekit.core_api.event.Event` represent anything that is time-bound: an ``Event`` has a begin and an end, which are described as `pandas Timestamps <https://pandas.pydata.org/docs/reference/api/pandas.Timestamp.html>`_.
 
 Almost every other class in **OSEkit** inherits from ``Event``.
 
@@ -47,9 +47,9 @@ Different type of data
 Since **OSEkit** provides ways to manipulate different types of data (audio, spectro, etc.), the `Data` <-> `File` operations described in the :ref:`Data and Files <data_files>` section
 are managed in bases classes:
 
-- :class:`OSmOSE.core_api.base_file.BaseFile` represent any **file**
-- :class:`OSmOSE.core_api.base_item.BaseItem` represent any **item**
-- :class:`OSmOSE.core_api.base_data.BaseData` represent any **data**
+- :class:`osekit.core_api.base_file.BaseFile` represent any **file**
+- :class:`osekit.core_api.base_item.BaseItem` represent any **item**
+- :class:`osekit.core_api.base_data.BaseData` represent any **data**
 
 These base classes are then derived through inheritance to specialized classes for any data type. For example, **audio data** is manipulated through the
-:class:`OSmOSE.core_api.audio_data.AudioData` class.
+:class:`osekit.core_api.audio_data.AudioData` class.

--- a/docs/source/coreapi_usage.rst
+++ b/docs/source/coreapi_usage.rst
@@ -6,13 +6,13 @@ Usage
 Audio File
 ^^^^^^^^^^
 
-To turn an audio file into an **OSEkit** ``AudioFile`` (represented by the :class:`OSmOSE.core_api.audio_file.AudioFile` class), all you need is the path to the file and a begin timestamp.
+To turn an audio file into an **OSEkit** ``AudioFile`` (represented by the :class:`osekit.core_api.audio_file.AudioFile` class), all you need is the path to the file and a begin timestamp.
 
 Such begin timestamp can either be specified (as a :class:`pandas.Timestamp` instance), or parsed from the audio file name by specifing the `strptime format <https://strftime.org/>`_:
 
 .. code-block:: python
 
-    from OSmOSE.core_api.audio_file import AudioFile
+    from osekit.core_api.audio_file import AudioFile
     from pathlib import Path
 
     af = AudioFile(
@@ -26,18 +26,18 @@ Audio Data
 Design
 """"""
 
-The :class:`OSmOSE.core_api.audio_data.AudioData` class represent a chunk of audio taken between two specific timestamps from one or more `AudioFile` instances.
+The :class:`osekit.core_api.audio_data.AudioData` class represent a chunk of audio taken between two specific timestamps from one or more `AudioFile` instances.
 
 This class offers means of easily resample the data and access it on-demand (with an optimized I/O workflow to minimize the file openings/closings).
 
-To create an ``AudioData`` from ``AudioFiles``, use the :meth:`OSmOSE.core_api.audio_data.AudioData.from_files` class method.
+To create an ``AudioData`` from ``AudioFiles``, use the :meth:`osekit.core_api.audio_data.AudioData.from_files` class method.
 
 Example for an ``AudioData`` representing the first 2 seconds of the ``foo/7189.230405154906.wav`` audio file:
 
 .. code-block:: python
 
     from pandas import Timestamp, Timedelta
-    from OSmOSE.core_api.audio_data import AudioData
+    from osekit.core_api.audio_data import AudioData
 
     ad = AudioData.from_files(
     files=[af],
@@ -104,9 +104,9 @@ Item 4
 Reading data
 """"""""""""
 
-The :meth:`OSmOSE.core_api.audio_data.AudioData.get_value` method returns a `numpy.ndarray <https://numpy.org/doc/stable/reference/generated/numpy.ndarray.html>`_ that contains the wav values of the audio data.
+The :meth:`osekit.core_api.audio_data.AudioData.get_value` method returns a `numpy.ndarray <https://numpy.org/doc/stable/reference/generated/numpy.ndarray.html>`_ that contains the wav values of the audio data.
 
-The data is fetched seamlessly on-demand from the audio file(s). The opening/closing of the audio files is optimized thanks to a :class:`OSmOSE.core_api.audio_file_manager.AudioFileManager` instance.
+The data is fetched seamlessly on-demand from the audio file(s). The opening/closing of the audio files is optimized thanks to a :class:`osekit.core_api.audio_file_manager.AudioFileManager` instance.
 
 Eventual time gap between audio items are filled with ``0.`` values.
 
@@ -116,16 +116,16 @@ Calibration
 
 .. _instrument_calibration:
 
-The :class:`OSmOSE.core_api.instrument.Instrument` class can be used to provide calibration info to your audio data.
+The :class:`osekit.core_api.instrument.Instrument` class can be used to provide calibration info to your audio data.
 This can be used to convert raw WAV data to the recorded acoustic pressure.
 
-An ``Instrument`` instance can be attached to an ``AudioData``. Then, the :meth:`OSmOSE.core_api.audio_data.AudioData.get_value_calibrated` method
+An ``Instrument`` instance can be attached to an ``AudioData``. Then, the :meth:`osekit.core_api.audio_data.AudioData.get_value_calibrated` method
 allows for retrieving the data in the shape of the recorded acoustic pressure.
 
 .. code-block:: python
 
-    from OSmOSE.core_api.instrument import Instrument
-    from OSmOSE.core_api.audio_data import AudioData
+    from osekit.core_api.instrument import Instrument
+    from osekit.core_api.audio_data import AudioData
     import numpy as np
 
     instrument = Instrument(end_to_end_db = 150) # The raw 1. WAV value equals 150 dB SPL re 1 uPa
@@ -138,13 +138,13 @@ allows for retrieving the data in the shape of the recorded acoustic pressure.
 Resampling
 """"""""""
 
-``AudioData`` can be resampled just by modifying the :attr:`OSmOSE.core_api.audio_data.AudioData.sample_rate` field.
+``AudioData`` can be resampled just by modifying the :attr:`osekit.core_api.audio_data.AudioData.sample_rate` field.
 
 Modifying the sample rate will not access the data, but the data will be resampled on the fly when it is requested:
 
 .. code-block:: python
 
-    from OSmOSE.core_api.audio_data import AudioData
+    from osekit.core_api.audio_data import AudioData
 
     ad = AudioData(...)
     ad.sample_rate = 48_000 # Resample the signal at 48 kHz. Nothing happens yet
@@ -154,7 +154,7 @@ Modifying the sample rate will not access the data, but the data will be resampl
 Audio Dataset
 ^^^^^^^^^^^^^
 
-The :class:`OSmOSE.core_api.audio_dataset.AudioDataset` class enables the instantiation and manipulation of large amounts of
+The :class:`osekit.core_api.audio_dataset.AudioDataset` class enables the instantiation and manipulation of large amounts of
 ``AudioData`` objects with simple operations.
 
 Instantiation
@@ -163,13 +163,13 @@ Instantiation
 The constructor of the ``AudioDataset`` class accepts a list of ``AudioData`` as parameter.
 
 But this is not the only way to create an audio dataset.
-The :meth:`OSmOSE.core_api.audio_dataset.AudioDataset.from_folder` class method allows to easily instantiate
+The :meth:`osekit.core_api.audio_dataset.AudioDataset.from_folder` class method allows to easily instantiate
 an ``AudioDataset`` from a given folder containing audio files:
 
 .. code-block:: python
 
     from pathlib import Path
-    from OSmOSE.core_api.audio_dataset import AudioDataset
+    from osekit.core_api.audio_dataset import AudioDataset
     from pandas import Timestamp, Timedelta
 
     folder = Path(r"...")
@@ -197,7 +197,7 @@ If one wanted to resample these 10s-long audio data and export them as wav files
     ads.sample_rate = 48_000 # The sample rate of all AudioData will be edited
     ads.write(folder / "output") # All audio data will be exported to wav files in that folder
 
-All the ``AudioData`` constituting the ``AudioDataset`` are accessible through the :attr:`OSmOSE.core_api.audio_dataset.AudioDataset.data`
+All the ``AudioData`` constituting the ``AudioDataset`` are accessible through the :attr:`osekit.core_api.audio_dataset.AudioDataset.data`
 field:
 
 .. code-block:: python
@@ -214,14 +214,14 @@ field:
 Spectro Data
 ^^^^^^^^^^^^
 
-The :class:`OSmOSE.core_api.spectro_data.SpectroData` class allows to perform spectral computations and to plot spectrograms from ``AudioData`` objects.
+The :class:`osekit.core_api.spectro_data.SpectroData` class allows to perform spectral computations and to plot spectrograms from ``AudioData`` objects.
 
 The most straightforward way to instantiate a ``SpectroData`` is from an ``AudioData`` and a `scipy.signal.ShortTimeFFT <https://docs.scipy.org/doc//scipy/reference/generated/scipy.signal.ShortTimeFFT.html>`_ instance:
 
 .. code-block:: python
 
-    from OSmOSE.core_api.audio_data import AudioData
-    from OSmOSE.core_api.spectro_data import SpectroData
+    from osekit.core_api.audio_data import AudioData
+    from osekit.core_api.spectro_data import SpectroData
     from scipy.signal import ShortTimeFFT
     from scipy.signal.windows import hamming
 
@@ -240,14 +240,14 @@ Once again, no audio has yet been fetched: everything happens only on-demand.
 NPZ matrices
 """"""""""""
 
-The ``SpectroData`` object can be used to compute the spectrum matrices of the ``AudioData`` with the :meth:`OSmOSE.core_api.spectro_data.SpectroData.get_value` method.
+The ``SpectroData`` object can be used to compute the spectrum matrices of the ``AudioData`` with the :meth:`osekit.core_api.spectro_data.SpectroData.get_value` method.
 
-The :attr:`OSmOSE.core_api.spectro_data.SpectroData.sx_dtype` property can be set to either ``complex`` (default) or ``float`` to return either the spectrum matrices as complex numbers or absolute values, respectively.
+The :attr:`osekit.core_api.spectro_data.SpectroData.sx_dtype` property can be set to either ``complex`` (default) or ``float`` to return either the spectrum matrices as complex numbers or absolute values, respectively.
 
-The spectrum matrices can be converted to decibels thanks to the :meth:`OSmOSE.core_api.spectro_data.SpectroData.to_db` method.
+The spectrum matrices can be converted to decibels thanks to the :meth:`osekit.core_api.spectro_data.SpectroData.to_db` method.
 This method will convert the matrix values either to dB SPL (re ``Instrument.P_REF``) if an :ref:`Instrument <instrument_calibration>` was provided to the ``AudioData`` or to dB FS otherwise.
 
-The spectrum matrices can then be exported to npz files thanks to the :meth:`OSmOSE.core_api.spectro_data.SpectroData.write` method.
+The spectrum matrices can then be exported to npz files thanks to the :meth:`osekit.core_api.spectro_data.SpectroData.write` method.
 
 .. code-block:: python
 
@@ -264,14 +264,14 @@ The spectrum matrices can then be exported to npz files thanks to the :meth:`OSm
 Plot and export
 """""""""""""""
 
-Spectrograms can be plotted from the ``SpectroData`` objects thanks to the :meth:`OSmOSE.core_api.spectro_data.SpectroData.plot` method.
+Spectrograms can be plotted from the ``SpectroData`` objects thanks to the :meth:`osekit.core_api.spectro_data.SpectroData.plot` method.
 
 OSEkit uses `pyplot <https://matplotlib.org/stable/tutorials/pyplot.html>`_ for plotting spectrograms. A pyplot `Axes <https://matplotlib.org/stable/api/_as_gen/matplotlib.axes.Axes.html#matplotlib.axes.Axes>`_
 can be provided to the ``SpectroData.plot()`` method to specify an Axes in which to plot the spectrogram:
 
 .. code-block:: python
 
-    from OSmOSE.core_api.spectro_data import SpectroData
+    from osekit.core_api.spectro_data import SpectroData
     import matplotlib.pyplot as plt
 
     sd = SpectroData(...) # See SpectroData documentation
@@ -286,14 +286,14 @@ can be provided to the ``SpectroData.plot()`` method to specify an Axes in which
 Custom frequency scales
 """""""""""""""""""""""
 
-The y-axis of the spectrograms can be parametrized thanks to the :class:`OSmOSE.core_api.frequency_scale.Scale` class.
+The y-axis of the spectrograms can be parametrized thanks to the :class:`osekit.core_api.frequency_scale.Scale` class.
 
-The custom ``Scale`` is made of ``ScalePart`` (:class:`OSmOSE.core_api.frequency_scale.ScalePart`). Each ``ScalePart``
+The custom ``Scale`` is made of ``ScalePart`` (:class:`osekit.core_api.frequency_scale.ScalePart`). Each ``ScalePart``
 correspond to a given frequency range on a given area of the y-axis:
 
 .. code-block:: python
 
-    from OSmOSE.core_api.frequency_scale import Scale, ScalePart
+    from osekit.core_api.frequency_scale import Scale, ScalePart
 
     scale = Scale(
         [
@@ -331,7 +331,7 @@ The resulting figure presents the full-scale spectrogram at the top (from 0 to 7
 LTAS Data
 ^^^^^^^^^
 
-OSEkit provides the :class:`OSmOSE.core_api.ltas_data.LTASData` class for computing and plotting LTAS (**L**\ ong-\ **T**\ erm **A**\ verage **S**\ pectrum).
+OSEkit provides the :class:`osekit.core_api.ltas_data.LTASData` class for computing and plotting LTAS (**L**\ ong-\ **T**\ erm **A**\ verage **S**\ pectrum).
 
 LTAS are suitable when a spectrum is computed over a very long time and that the spectrum matrix time dimension reach a really high value.
 In that case, time bins can be averaged to form a LTAS, which time resolution is lower than that of the original spectrum.
@@ -361,4 +361,4 @@ should be provided:
     ltas.plot()
     plt.show()
 
-A ``SpectroData`` object can be turned into a ``LTASData`` thanks to the :meth:`OSmOSE.core_api.ltas_data.LTASData.from_spectro_data` method.
+A ``SpectroData`` object can be turned into a ``LTASData`` thanks to the :meth:`osekit.core_api.ltas_data.LTASData.from_spectro_data` method.

--- a/docs/source/coreapi_usage.rst
+++ b/docs/source/coreapi_usage.rst
@@ -184,6 +184,9 @@ an ``AudioDataset`` from a given folder containing audio files:
 
 The resulting ``AudioDataset`` will contain 10s-long ``AudioData`` ranging from ``2009-01-06 12:00:00`` to ``2009-01-06 14:00:00``.
 
+This is the default behaviour, but other ways of computing the ``AudioData`` time locations are available through the
+:meth:`osekit.core_api.audio_dataset.AudioDataset.from_folder` ``mode`` parameter (see the API documentation for more info).
+
 You don't have to worry about the shape of the original audio files: audio data will be fetched seamlessly in the corresponding
 file(s) whenever you need it.
 

--- a/docs/source/dataset.rst
+++ b/docs/source/dataset.rst
@@ -3,5 +3,5 @@ Dataset
 
 .. _dataset:
 
-.. autoclass:: OSmOSE.public_api.dataset.Dataset
+.. autoclass:: osekit.public_api.dataset.Dataset
    :members:

--- a/docs/source/event.rst
+++ b/docs/source/event.rst
@@ -3,5 +3,5 @@ Event
 
 .. _event:
 
-.. autoclass:: OSmOSE.core_api.event.Event
+.. autoclass:: osekit.core_api.event.Event
    :members:

--- a/docs/source/frequencyscale.rst
+++ b/docs/source/frequencyscale.rst
@@ -3,8 +3,8 @@ Custom Frequency Scale
 
 .. _frequencyscale:
 
-.. autoclass:: OSmOSE.core_api.frequency_scale.Scale
+.. autoclass:: osekit.core_api.frequency_scale.Scale
    :members:
 
-.. autoclass:: OSmOSE.core_api.frequency_scale.ScalePart
+.. autoclass:: osekit.core_api.frequency_scale.ScalePart
    :members:

--- a/docs/source/instrument.rst
+++ b/docs/source/instrument.rst
@@ -3,5 +3,5 @@ Instrument
 
 .. _instrument:
 
-.. autoclass:: OSmOSE.core_api.instrument.Instrument
+.. autoclass:: osekit.core_api.instrument.Instrument
    :members:

--- a/docs/source/ltasdata.rst
+++ b/docs/source/ltasdata.rst
@@ -3,5 +3,5 @@ LTASData
 
 .. _ltasdata:
 
-.. autoclass:: OSmOSE.core_api.ltas_data.LTASData
+.. autoclass:: osekit.core_api.ltas_data.LTASData
    :members:

--- a/docs/source/publicapi_usage.rst
+++ b/docs/source/publicapi_usage.rst
@@ -7,7 +7,7 @@ This API provides tools for working on large sets of audio data.
 
 Basically, the whole point of **OSEkit**'s Public API is to export large amounts of spectrograms and/or reshaped audio files with no consideration of the original format of the audio files.
 
-The :class:`OSmOSE.public_api.dataset.Dataset` class is the cornerstone of **OSEkit**'s Public API.
+The :class:`osekit.public_api.dataset.Dataset` class is the cornerstone of **OSEkit**'s Public API.
 
 Building a ``Dataset``
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -31,11 +31,11 @@ For example, this folder containing 4 audio files plus some extra files:
 Only the folder path and strptime format are required to initialize the ``Dataset``.
 
 Extra parameters allow for e.g. localizing the files in a specific timezone or accounting for the measurement chain to link the raw wav data to the measured acoustic presure.
-The complete list of extra parameters is provided in the :class:`OSmOSE.public_api.dataset.Dataset` documentation.
+The complete list of extra parameters is provided in the :class:`osekit.public_api.dataset.Dataset` documentation.
 
 .. code-block:: python
 
-    from OSmOSE.public_api.dataset import Dataset
+    from osekit.public_api.dataset import Dataset
     from pathlib import Path
 
     dataset = Dataset(
@@ -43,7 +43,7 @@ The complete list of extra parameters is provided in the :class:`OSmOSE.public_a
         strptime_format="%y%m%d%H%M%S" # Must match the strptime format of your audio files
     )
 
-Once this is done, the ``Dataset`` can be built using the :meth:`OSmOSE.public_api.dataset.Dataset.build` method.
+Once this is done, the ``Dataset`` can be built using the :meth:`osekit.public_api.dataset.Dataset.build` method.
 
 .. code-block:: python
 
@@ -68,8 +68,8 @@ The folder is now organized in the following fashion:
     └── bar.txt
     dataset.json
 
-The **original audio files** have been turned into a :class:`OSmOSE.core_api.audio_dataset.AudioDataset`.
-In this ``AudioDataset``, one :class:`OSmOSE.core_api.audio_data.AudioData` has been created per original audio file.
+The **original audio files** have been turned into a :class:`osekit.core_api.audio_dataset.AudioDataset`.
+In this ``AudioDataset``, one :class:`osekit.core_api.audio_data.AudioData` has been created per original audio file.
 Additionally, both this Core API ``Audiodataset`` and the Public API ``Dataset`` have been serialized
 into the ``original.json`` and ``dataset.json`` files, respectively.
 
@@ -77,18 +77,18 @@ into the ``original.json`` and ``dataset.json`` files, respectively.
 Running an ``Analysis``
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-In **OSEkit**, **Analyses** are run with the :meth:`OSmOSE.public_api.dataset.Dataset.run_analysis` method to process and export spectrogram images, spectrum matrices and audio files from original audio files.
+In **OSEkit**, **Analyses** are run with the :meth:`osekit.public_api.dataset.Dataset.run_analysis` method to process and export spectrogram images, spectrum matrices and audio files from original audio files.
 
 .. note::
 
     **OSEkit** makes it easy to **reshape** the original audio: it is not bound to the original files, and can freely be reshaped in audio data of **any duration and sample rate**.
 
-The analysis parameters are described by a :class:`OSmOSE.public_api.analysis.Analysis` instance passed as a parameter to this method.
+The analysis parameters are described by a :class:`osekit.public_api.analysis.Analysis` instance passed as a parameter to this method.
 
 Analysis Type
 """""""""""""
 
-The ``analysis_type`` parameter passed to the initializer is a :class:`OSmOSE.public_api.analysis.AnalysisType` instance that defines the analysis output(s):
+The ``analysis_type`` parameter passed to the initializer is a :class:`osekit.public_api.analysis.AnalysisType` instance that defines the analysis output(s):
 
 .. list-table:: Analysis Types
    :widths: 40 60
@@ -111,14 +111,14 @@ For example, if an analysis aims at exporting both the reshaped audio files and 
 
 .. code-block:: python
 
-    from OSmOSE.public_api.analysis import AnalysisType
+    from osekit.public_api.analysis import AnalysisType
     analysis_type = AnalysisType.AUDIO | AnalysisType.SPECTROGRAM
 
 
 Analysis Parameters
 """""""""""""""""""
 
-The remaining parameters of the analysis (begin and end **Timestamps**, duration and sample rate of the reshaped data...) are described in the :class:`OSmOSE.public_api.analysis.Analysis` initializer docstring.
+The remaining parameters of the analysis (begin and end **Timestamps**, duration and sample rate of the reshaped data...) are described in the :class:`osekit.public_api.analysis.Analysis` initializer docstring.
 
 .. note::
 
@@ -130,8 +130,8 @@ Checking/Editing the analysis
 
 .. _editing_analysis:
 
-If you want to take a peek at what the analysis output will be before actually running it, the :meth:`OSmOSE.public_api.dataset.Dataset.get_analysis_audiodataset` and :meth:`OSmOSE.public_api.dataset.Dataset.get_analysis_spectrodataset` methods
-return a :class:`OSmOSE.core_api.audio_dataset.AudioDataset` and a :class:`OSmOSE.core_api.spectro_dataset.SpectroDataset` instance, respectively.
+If you want to take a peek at what the analysis output will be before actually running it, the :meth:`osekit.public_api.dataset.Dataset.get_analysis_audiodataset` and :meth:`osekit.public_api.dataset.Dataset.get_analysis_spectrodataset` methods
+return a :class:`osekit.core_api.audio_dataset.AudioDataset` and a :class:`osekit.core_api.spectro_dataset.SpectroDataset` instance, respectively.
 
 The returned ``AudioDataset`` can be edited at will and passed as a parameter later on when the analysis is run:
 
@@ -158,7 +158,7 @@ The returned ``SpectroDataset`` can be used e.g. to plot sample spectrograms pri
 Running the analysis
 """"""""""""""""""""
 
-To run the ``Analysis``, simply execute the :meth:`OSmOSE.public_api.dataset.Dataset.run_analysis` method:
+To run the ``Analysis``, simply execute the :meth:`osekit.public_api.dataset.Dataset.run_analysis` method:
 
 .. code-block:: python
 
@@ -179,7 +179,7 @@ The corresponding ``Analysis`` is the following:
 
 .. code-block:: python
 
-    from OSmOSE.public_api.analysis import Analysis, AnalysisType
+    from osekit.public_api.analysis import Analysis, AnalysisType
     from pandas import Timedelta
 
     analysis = Analysis(
@@ -196,7 +196,7 @@ Output 1
 
 .. _output_1:
 
-Once the analysis is run, a :class:`OSmOSE.core_api.audio_dataset.AudioDataset` instance named ``cool_reshape`` has been created and added to the dataset's :attr:`OSmOSE.public_api.dataset.Dataset.datasets` field.
+Once the analysis is run, a :class:`osekit.core_api.audio_dataset.AudioDataset` instance named ``cool_reshape`` has been created and added to the dataset's :attr:`osekit.public_api.dataset.Dataset.datasets` field.
 
 The dataset folder now looks like this:
 
@@ -270,7 +270,7 @@ Then we are all set for running the analysis:
 
 .. code-block:: python
 
-    from OSmOSE.public_api.analysis import Analysis, AnalysisType
+    from osekit.public_api.analysis import Analysis, AnalysisType
     from pandas import Timedelta
 
     analysis = Analysis(
@@ -288,10 +288,10 @@ Then we are all set for running the analysis:
 Output 2
 """"""""
 
-Since the analysis contains both ``AnalysisType.AUDIO`` and spectral analysis types, two core API datasets were created and added to the dataset's :attr:`OSmOSE.public_api.dataset.Dataset.datasets` field:
+Since the analysis contains both ``AnalysisType.AUDIO`` and spectral analysis types, two core API datasets were created and added to the dataset's :attr:`osekit.public_api.dataset.Dataset.datasets` field:
 
-* A :class:`OSmOSE.core_api.audio_dataset.AudioDataset` named ``full_analysis_audio`` (with the *_audio* suffix)
-* A :class:`OSmOSE.core_api.spectro_dataset.SpectroDataset` named ``full_analysis``
+* A :class:`osekit.core_api.audio_dataset.AudioDataset` named ``full_analysis_audio`` (with the *_audio* suffix)
+* A :class:`osekit.core_api.spectro_dataset.SpectroDataset` named ``full_analysis``
 
 The dataset folder now looks like this (the output from the first example was removed for convenience):
 
@@ -340,18 +340,18 @@ The dataset folder now looks like this (the output from the first example was re
 
 As in :ref:`the output of example 1 <output_1>`, a ``full_analysis_audio`` folder was created, containing the reshaped audio files.
 
-Additionally, the fresh ``processed`` folder contains the output spectrograms and NPZ matrices, along with the ``full_analysis.json`` serialized :class:`OSmOSE.core_api.spectro_dataset.SpectroDataset`.
+Additionally, the fresh ``processed`` folder contains the output spectrograms and NPZ matrices, along with the ``full_analysis.json`` serialized :class:`osekit.core_api.spectro_dataset.SpectroDataset`.
 
 
 Recovering a ``Dataset``
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-The ``dataset.json`` file in the root dataset folder can be used to deserialize a :class:`OSmOSE.public_api.dataset.Dataset` object thanks to the :meth:`OSmOSE.public_api.dataset.Dataset.from_json` method:
+The ``dataset.json`` file in the root dataset folder can be used to deserialize a :class:`osekit.public_api.dataset.Dataset` object thanks to the :meth:`osekit.public_api.dataset.Dataset.from_json` method:
 
 .. code-block:: python
 
     from pathlib import Path
-    from OSmOSE.public_api.dataset import Dataset
+    from osekit.public_api.dataset import Dataset
 
     json_file = Path(r"../dataset.json")
     dataset = Dataset.from_json(json_file) # That's it!
@@ -364,5 +364,5 @@ Resetting a ``Dataset``
 
     Calling this method is irreversible
 
-The :meth:`OSmOSE.public_api.dataset.Dataset.reset` method **resets the dataset's folder** to its initial state.
+The :meth:`osekit.public_api.dataset.Dataset.reset` method **resets the dataset's folder** to its initial state.
 All exported analyses ans json files will be removed, and the folder will be back to its state :ref:`before building the dataset <build>`.

--- a/docs/source/spectrodata.rst
+++ b/docs/source/spectrodata.rst
@@ -3,5 +3,5 @@ SpectroData
 
 .. _spectrodata:
 
-.. autoclass:: OSmOSE.core_api.spectro_data.SpectroData
+.. autoclass:: osekit.core_api.spectro_data.SpectroData
    :members:

--- a/docs/source/spectrodataset.rst
+++ b/docs/source/spectrodataset.rst
@@ -3,5 +3,5 @@ SpectroDataset
 
 .. _spectrodataset:
 
-.. autoclass:: OSmOSE.core_api.spectro_dataset.SpectroDataset
+.. autoclass:: osekit.core_api.spectro_dataset.SpectroDataset
    :members:

--- a/docs/source/spectrofile.rst
+++ b/docs/source/spectrofile.rst
@@ -3,5 +3,5 @@ SpectroFile
 
 .. _spectrofile:
 
-.. autoclass:: OSmOSE.core_api.spectro_file.SpectroFile
+.. autoclass:: osekit.core_api.spectro_file.SpectroFile
    :members:

--- a/docs/source/spectroitem.rst
+++ b/docs/source/spectroitem.rst
@@ -3,5 +3,5 @@ SpectroItem
 
 .. _spectroitem:
 
-.. autoclass:: OSmOSE.core_api.spectro_item.SpectroItem
+.. autoclass:: osekit.core_api.spectro_item.SpectroItem
    :members:

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -4,7 +4,7 @@
 .. _usage:
 
 In **OSEkit**, data is manipulated as **events** (which means something that has absolute **begin** and **end** timestamps).
-All data classes from the API inherit from the :class:`OSmOSE.core_api.event.Event` class, allowing for easy timestamp-based manipulations of different types of data.
+All data classes from the API inherit from the :class:`osekit.core_api.event.Event` class, allowing for easy timestamp-based manipulations of different types of data.
 
 The package combines two APIs:
 

--- a/src/osekit/core_api/audio_dataset.py
+++ b/src/osekit/core_api/audio_dataset.py
@@ -116,7 +116,8 @@ class AudioDataset(BaseDataset[AudioData, AudioFile]):
         """
         last = len(self.data) if last is None else last
         for data in tqdm(
-            self.data[first:last], disable=os.environ.get("DISABLE_TQDM", "")
+            self.data[first:last],
+            disable=os.environ.get("DISABLE_TQDM", ""),
         ):
             data.write(folder=folder, subtype=subtype, link=link)
 
@@ -150,7 +151,7 @@ class AudioDataset(BaseDataset[AudioData, AudioFile]):
         begin: Timestamp | None = None,
         end: Timestamp | None = None,
         timezone: str | pytz.timezone | None = None,
-        bound: Literal["files", "timedelta"] = "timedelta",
+        mode: Literal["files", "timedelta_total", "timedelta_file"] = "timedelta_total",
         data_duration: Timedelta | None = None,
         name: str | None = None,
         instrument: Instrument | None = None,
@@ -176,14 +177,19 @@ class AudioDataset(BaseDataset[AudioData, AudioFile]):
             If different from a timezone parsed from the filename, the timestamps'
             timezone will be converted from the parsed timezone
             to the specified timezone.
-        bound: Literal["files", "timedelta"]
-            Bound between the original files and the dataset data.
+        mode: Literal["files", "timedelta_total", "timedelta_file"]
+            Mode of creation of the dataset data from the original files.
             "files": one data will be created for each file.
-            "timedelta": data objects of duration equal to data_duration will
-            be created.
+            "timedelta_total": data objects of duration equal to data_duration will
+            be created from the very beginning to the very end of the
+            original files duration.
+            "timedelta_file": data objects of duration equal to data_duration will
+            be created from the beginning of each original file until it would resume
+            in an empty data. Then, the next data object will be created from the
+            beginning of the next original file.
         data_duration: Timedelta | None
             Duration of the audio data objects.
-            If bound is set to "files", this parameter has no effect.
+            If mode is set to "files", this parameter has no effect.
             If provided, audio data will be evenly distributed between begin and end.
             Else, one data object will cover the whole time period.
         name: str|None
@@ -209,7 +215,7 @@ class AudioDataset(BaseDataset[AudioData, AudioFile]):
             begin=begin,
             end=end,
             timezone=timezone,
-            bound=bound,
+            mode=mode,
             data_duration=data_duration,
             **kwargs,
         )
@@ -225,7 +231,7 @@ class AudioDataset(BaseDataset[AudioData, AudioFile]):
         files: list[AudioFile],
         begin: Timestamp | None = None,
         end: Timestamp | None = None,
-        bound: Literal["files", "timedelta"] = "timedelta",
+        mode: Literal["files", "timedelta_total", "timedelta_file"] = "timedelta_total",
         data_duration: Timedelta | None = None,
         name: str | None = None,
         instrument: Instrument | None = None,
@@ -242,14 +248,19 @@ class AudioDataset(BaseDataset[AudioData, AudioFile]):
         end: Timestamp | None
             End of the last data object.
             Defaulted to the end of the last file.
-        bound: Literal["files", "timedelta"]
-            Bound between the original files and the dataset data.
+        mode: Literal["files", "timedelta_total", "timedelta_file"]
+            Mode of creation of the dataset data from the original files.
             "files": one data will be created for each file.
-            "timedelta": data objects of duration equal to data_duration will
-            be created.
+            "timedelta_total": data objects of duration equal to data_duration will
+            be created from the very beginning to the very end of the
+            original files duration.
+            "timedelta_file": data objects of duration equal to data_duration will
+            be created from the beginning of each original file until it would resume
+            in an empty data. Then, the next data object will be created from the
+            beginning of the next original file.
         data_duration: Timedelta | None
             Duration of the data objects.
-            If bound is set to "files", this parameter has no effect.
+            If mode is set to "files", this parameter has no effect.
             If provided, data will be evenly distributed between begin and end.
             Else, one data object will cover the whole time period.
         name: str|None
@@ -268,7 +279,7 @@ class AudioDataset(BaseDataset[AudioData, AudioFile]):
             files=files,
             begin=begin,
             end=end,
-            bound=bound,
+            mode=mode,
             data_duration=data_duration,
         )
         return cls.from_base_dataset(base, name=name, instrument=instrument)

--- a/src/osekit/core_api/audio_dataset.py
+++ b/src/osekit/core_api/audio_dataset.py
@@ -181,12 +181,11 @@ class AudioDataset(BaseDataset[AudioData, AudioFile]):
             Mode of creation of the dataset data from the original files.
             "files": one data will be created for each file.
             "timedelta_total": data objects of duration equal to data_duration will
-            be created from the very beginning to the very end of the
-            original files duration.
+            be created from the begin timestamp to the end timestamp.
             "timedelta_file": data objects of duration equal to data_duration will
-            be created from the beginning of each original file until it would resume
-            in an empty data. Then, the next data object will be created from the
-            beginning of the next original file.
+            be created from the beginning of the first file that the begin timestamp is into, until it would resume
+            in a data beginning between two files. Then, the next data object will be created from the
+            beginning of the next original file and so on.
         data_duration: Timedelta | None
             Duration of the audio data objects.
             If mode is set to "files", this parameter has no effect.
@@ -252,12 +251,11 @@ class AudioDataset(BaseDataset[AudioData, AudioFile]):
             Mode of creation of the dataset data from the original files.
             "files": one data will be created for each file.
             "timedelta_total": data objects of duration equal to data_duration will
-            be created from the very beginning to the very end of the
-            original files duration.
+            be created from the begin timestamp to the end timestamp.
             "timedelta_file": data objects of duration equal to data_duration will
-            be created from the beginning of each original file until it would resume
-            in an empty data. Then, the next data object will be created from the
-            beginning of the next original file.
+            be created from the beginning of the first file that the begin timestamp is into, until it would resume
+            in a data beginning between two files. Then, the next data object will be created from the
+            beginning of the next original file and so on.
         data_duration: Timedelta | None
             Duration of the data objects.
             If mode is set to "files", this parameter has no effect.

--- a/src/osekit/core_api/base_dataset.py
+++ b/src/osekit/core_api/base_dataset.py
@@ -271,12 +271,11 @@ class BaseDataset(Generic[TData, TFile], Event):
             Mode of creation of the dataset data from the original files.
             "files": one data will be created for each file.
             "timedelta_total": data objects of duration equal to data_duration will
-            be created from the very beginning to the very end of the
-            original files duration.
+            be created from the begin timestamp to the end timestamp.
             "timedelta_file": data objects of duration equal to data_duration will
-            be created from the beginning of each original file until it would resume
-            in an empty data. Then, the next data object will be created from the
-            beginning of the next original file.
+            be created from the beginning of the first file that the begin timestamp is into, until it would resume
+            in a data beginning between two files. Then, the next data object will be created from the
+            beginning of the next original file and so on.
         data_duration: Timedelta | None
             Duration of the data objects.
             If mode is set to "files", this parameter has no effect.
@@ -442,12 +441,11 @@ class BaseDataset(Generic[TData, TFile], Event):
             Mode of creation of the dataset data from the original files.
             "files": one data will be created for each file.
             "timedelta_total": data objects of duration equal to data_duration will
-            be created from the very beginning to the very end of the
-            original files duration.
+            be created from the begin timestamp to the end timestamp.
             "timedelta_file": data objects of duration equal to data_duration will
-            be created from the beginning of each original file until it would resume
-            in an empty data. Then, the next data object will be created from the
-            beginning of the next original file.
+            be created from the beginning of the first file that the begin timestamp is into, until it would resume
+            in a data beginning between two files. Then, the next data object will be created from the
+            beginning of the next original file and so on.
         data_duration: Timedelta | None
             Duration of the data objects.
             If mode is set to "files", this parameter has no effect.

--- a/src/osekit/core_api/base_dataset.py
+++ b/src/osekit/core_api/base_dataset.py
@@ -6,7 +6,9 @@ that simplify repeated operations on the data.
 
 from __future__ import annotations
 
+import math
 import os
+from bisect import bisect
 from pathlib import Path
 from typing import TYPE_CHECKING, Generic, Literal, TypeVar
 
@@ -249,7 +251,7 @@ class BaseDataset(Generic[TData, TFile], Event):
         files: list[TFile],
         begin: Timestamp | None = None,
         end: Timestamp | None = None,
-        bound: Literal["files", "timedelta"] = "timedelta",
+        mode: Literal["files", "timedelta_total", "timedelta_file"] = "timedelta_total",
         data_duration: Timedelta | None = None,
         name: str | None = None,
     ) -> BaseDataset:
@@ -265,14 +267,19 @@ class BaseDataset(Generic[TData, TFile], Event):
         end: Timestamp | None
             End of the last data object.
             Defaulted to the end of the last file.
-        bound: Literal["files", "timedelta"]
-            Bound between the original files and the dataset data.
+        mode: Literal["files", "timedelta_total", "timedelta_file"]
+            Mode of creation of the dataset data from the original files.
             "files": one data will be created for each file.
-            "timedelta": data objects of duration equal to data_duration will
-            be created.
+            "timedelta_total": data objects of duration equal to data_duration will
+            be created from the very beginning to the very end of the
+            original files duration.
+            "timedelta_file": data objects of duration equal to data_duration will
+            be created from the beginning of each original file until it would resume
+            in an empty data. Then, the next data object will be created from the
+            beginning of the next original file.
         data_duration: Timedelta | None
             Duration of the data objects.
-            If bound is set to "files", this parameter has no effect.
+            If mode is set to "files", this parameter has no effect.
             If provided, data will be evenly distributed between begin and end.
             Else, one data object will cover the whole time period.
         name: str|None
@@ -284,7 +291,7 @@ class BaseDataset(Generic[TData, TFile], Event):
         The DataBase object.
 
         """
-        if bound == "files":
+        if mode == "files":
             data_base = [BaseData.from_files([f]) for f in files]
             data_base = BaseData.remove_overlaps(data_base)
             return cls(data=data_base, name=name)
@@ -294,13 +301,27 @@ class BaseDataset(Generic[TData, TFile], Event):
         if not end:
             end = max(file.end for file in files)
         if data_duration:
-            data_base = cls._get_base_data_from_files(begin, end, data_duration, files)
+            data_base = (
+                cls._get_base_data_from_files_timedelta_total(
+                    begin,
+                    end,
+                    data_duration,
+                    files,
+                )
+                if mode == "timedelta_total"
+                else cls._get_base_data_from_files_timedelta_file(
+                    begin,
+                    end,
+                    data_duration,
+                    files,
+                )
+            )
         else:
             data_base = [BaseData.from_files(files, begin=begin, end=end)]
         return cls(data_base, name=name)
 
     @classmethod
-    def _get_base_data_from_files(
+    def _get_base_data_from_files_timedelta_total(
         cls,
         begin: Timestamp,
         end: Timestamp,
@@ -337,6 +358,49 @@ class BaseDataset(Generic[TData, TFile], Event):
         return output
 
     @classmethod
+    def _get_base_data_from_files_timedelta_file(
+        cls,
+        begin: Timestamp,
+        end: Timestamp,
+        data_duration: Timedelta,
+        files: list[TFile],
+    ) -> list[BaseData]:
+        files = sorted(files, key=lambda file: file.begin)
+        first = max(0, bisect(files, begin, key=lambda f: f.begin) - 1)
+        last = bisect(files, end, key=lambda f: f.begin)
+
+        output = []
+        files_chunk = []
+        for idx, file in tqdm(
+            enumerate(files[first:last]),
+            disable=os.environ.get("DISABLE_TQDM", ""),
+        ):
+            if file in files_chunk:
+                continue
+            files_chunk = [file]
+
+            for next_file in files[idx + 1 :]:
+                upper_data_limit = file.begin + data_duration * math.ceil(
+                    (files_chunk[-1].end - file.begin).total_seconds()
+                    / data_duration.total_seconds(),
+                )
+                if upper_data_limit < next_file.begin:
+                    break
+                files_chunk.append(next_file)
+
+            output.extend(
+                BaseData.from_files(files, data_begin, data_begin + data_duration)
+                for data_begin in date_range(
+                    file.begin,
+                    files_chunk[-1].end,
+                    freq=data_duration,
+                    inclusive="left",
+                )
+            )
+
+        return output
+
+    @classmethod
     def from_folder(  # noqa: PLR0913
         cls,
         folder: Path,
@@ -346,7 +410,7 @@ class BaseDataset(Generic[TData, TFile], Event):
         begin: Timestamp | None = None,
         end: Timestamp | None = None,
         timezone: str | pytz.timezone | None = None,
-        bound: Literal["files", "timedelta"] = "timedelta",
+        mode: Literal["files", "timedelta_total", "timedelta_file"] = "timedelta_total",
         data_duration: Timedelta | None = None,
         name: str | None = None,
     ) -> BaseDataset:
@@ -374,14 +438,19 @@ class BaseDataset(Generic[TData, TFile], Event):
             If different from a timezone parsed from the filename, the timestamps'
             timezone will be converted from the parsed timezone
             to the specified timezone.
-        bound: Literal["files", "timedelta"]
-            Bound between the original files and the dataset data.
+        mode: Literal["files", "timedelta_total", "timedelta_file"]
+            Mode of creation of the dataset data from the original files.
             "files": one data will be created for each file.
-            "timedelta": data objects of duration equal to data_duration will
-            be created.
+            "timedelta_total": data objects of duration equal to data_duration will
+            be created from the very beginning to the very end of the
+            original files duration.
+            "timedelta_file": data objects of duration equal to data_duration will
+            be created from the beginning of each original file until it would resume
+            in an empty data. Then, the next data object will be created from the
+            beginning of the next original file.
         data_duration: Timedelta | None
             Duration of the data objects.
-            If bound is set to "files", this parameter has no effect.
+            If mode is set to "files", this parameter has no effect.
             If provided, data will be evenly distributed between begin and end.
             Else, one object will cover the whole time period.
         name: str|None
@@ -419,7 +488,7 @@ class BaseDataset(Generic[TData, TFile], Event):
             files=valid_files,
             begin=begin,
             end=end,
-            bound=bound,
+            mode=mode,
             data_duration=data_duration,
             name=name,
         )

--- a/src/osekit/core_api/spectro_dataset.py
+++ b/src/osekit/core_api/spectro_dataset.py
@@ -143,7 +143,8 @@ class SpectroDataset(BaseDataset[SpectroData, SpectroFile]):
         """
         last = len(self.data) if last is None else last
         for data in tqdm(
-            self.data[first:last], disable=os.environ.get("DISABLE_TQDM", "")
+            self.data[first:last],
+            disable=os.environ.get("DISABLE_TQDM", ""),
         ):
             data.save_spectrogram(folder, scale=self.scale)
 
@@ -162,7 +163,8 @@ class SpectroDataset(BaseDataset[SpectroData, SpectroFile]):
         timestamps = []
         pxs = []
         for data in tqdm(
-            self.data[first:last], disable=os.environ.get("DISABLE_TQDM", "")
+            self.data[first:last],
+            disable=os.environ.get("DISABLE_TQDM", ""),
         ):
             timestamps.append(f"{data.begin!s}_{data.end!s}")
             pxs.append(
@@ -209,7 +211,8 @@ class SpectroDataset(BaseDataset[SpectroData, SpectroFile]):
         """
         last = len(self.data) if last is None else last
         for data in tqdm(
-            self.data[first:last], disable=os.environ.get("DISABLE_TQDM", "")
+            self.data[first:last],
+            disable=os.environ.get("DISABLE_TQDM", ""),
         ):
             sx = data.get_value()
             data.write(folder=matrix_folder, sx=sx, link=link)
@@ -367,7 +370,7 @@ class SpectroDataset(BaseDataset[SpectroData, SpectroFile]):
         begin: Timestamp | None = None,
         end: Timestamp | None = None,
         timezone: str | pytz.timezone | None = None,
-        bound: Literal["files", "timedelta"] = "timedelta",
+        mode: Literal["files", "timedelta_total", "timedelta_file"] = "timedelta_total",
         data_duration: Timedelta | None = None,
         name: str | None = None,
         v_lim: tuple[float, float] | None | object = __sentinel_value,
@@ -393,14 +396,19 @@ class SpectroDataset(BaseDataset[SpectroData, SpectroFile]):
             If different from a timezone parsed from the filename, the timestamps'
             timezone will be converted from the parsed timezone
             to the specified timezone.
-        bound: Literal["files", "timedelta"]
-            Bound between the original files and the dataset data.
+        mode: Literal["files", "timedelta_total", "timedelta_file"]
+            Mode of creation of the dataset data from the original files.
             "files": one data will be created for each file.
-            "timedelta": data objects of duration equal to data_duration will
-            be created.
+            "timedelta_total": data objects of duration equal to data_duration will
+            be created from the very beginning to the very end of the
+            original files duration.
+            "timedelta_file": data objects of duration equal to data_duration will
+            be created from the beginning of each original file until it would resume
+            in an empty data. Then, the next data object will be created from the
+            beginning of the next original file.
         data_duration: Timedelta | None
             Duration of the spectro data objects.
-            If bound is set to "files", this parameter has no effect.
+            If mode is set to "files", this parameter has no effect.
             If provided, spectro data will be evenly distributed between begin and end.
             Else, one data object will cover the whole time period.
         name: str|None
@@ -425,7 +433,7 @@ class SpectroDataset(BaseDataset[SpectroData, SpectroFile]):
             begin=begin,
             end=end,
             timezone=timezone,
-            bound=bound,
+            mode=mode,
             data_duration=data_duration,
             **kwargs,
         )

--- a/src/osekit/core_api/spectro_dataset.py
+++ b/src/osekit/core_api/spectro_dataset.py
@@ -400,12 +400,11 @@ class SpectroDataset(BaseDataset[SpectroData, SpectroFile]):
             Mode of creation of the dataset data from the original files.
             "files": one data will be created for each file.
             "timedelta_total": data objects of duration equal to data_duration will
-            be created from the very beginning to the very end of the
-            original files duration.
+            be created from the begin timestamp to the end timestamp.
             "timedelta_file": data objects of duration equal to data_duration will
-            be created from the beginning of each original file until it would resume
-            in an empty data. Then, the next data object will be created from the
-            beginning of the next original file.
+            be created from the beginning of the first file that the begin timestamp is into, until it would resume
+            in a data beginning between two files. Then, the next data object will be created from the
+            beginning of the next original file and so on.
         data_duration: Timedelta | None
             Duration of the spectro data objects.
             If mode is set to "files", this parameter has no effect.

--- a/src/osekit/public_api/analysis.py
+++ b/src/osekit/public_api/analysis.py
@@ -96,12 +96,11 @@ class Analysis:
             Mode of creation of the dataset data from the original files.
             "files": one data will be created for each file.
             "timedelta_total": data objects of duration equal to data_duration will
-            be created from the very beginning to the very end of the
-            original files duration.
+            be created from the begin timestamp to the end timestamp.
             "timedelta_file": data objects of duration equal to data_duration will
-            be created from the beginning of each original file until it would resume
-            in an empty data. Then, the next data object will be created from the
-            beginning of the next original file.
+            be created from the beginning of the first file that the begin timestamp is into, until it would resume
+            in a data beginning between two files. Then, the next data object will be created from the
+            beginning of the next original file and so on.
         sample_rate: float | None
             Sample rate of the new analysis data.
             Audio data will be resampled if provided, else the sample rate

--- a/src/osekit/public_api/analysis.py
+++ b/src/osekit/public_api/analysis.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from enum import Flag, auto
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from osekit.core_api.frequency_scale import Scale
 
@@ -66,6 +66,7 @@ class Analysis:
         begin: Timestamp | None = None,
         end: Timestamp | None = None,
         data_duration: Timedelta | None = None,
+        mode: Literal["files", "timedelta_total", "timedelta_file"] = "timedelta_total",
         sample_rate: float | None = None,
         name: str | None = None,
         subtype: str | None = None,
@@ -91,6 +92,16 @@ class Analysis:
             Duration of the data within the analysis dataset.
             If provided, audio data will be evenly distributed between begin and end.
             Else, one data object will cover the whole time period.
+        mode: Literal["files", "timedelta_total", "timedelta_file"]
+            Mode of creation of the dataset data from the original files.
+            "files": one data will be created for each file.
+            "timedelta_total": data objects of duration equal to data_duration will
+            be created from the very beginning to the very end of the
+            original files duration.
+            "timedelta_file": data objects of duration equal to data_duration will
+            be created from the beginning of each original file until it would resume
+            in an empty data. Then, the next data object will be created from the
+            beginning of the next original file.
         sample_rate: float | None
             Sample rate of the new analysis data.
             Audio data will be resampled if provided, else the sample rate
@@ -125,6 +136,7 @@ class Analysis:
         self.begin = begin
         self.end = end
         self.data_duration = data_duration
+        self.mode = mode
         self.sample_rate = sample_rate
         self.name = name
         self.subtype = subtype

--- a/src/osekit/public_api/dataset.py
+++ b/src/osekit/public_api/dataset.py
@@ -118,7 +118,7 @@ class Dataset:
         ads = AudioDataset.from_folder(
             self.folder,
             strptime_format=self.strptime_format,
-            bound="files",
+            mode="files",
             timezone=self.timezone,
             name="original",
             instrument=self.instrument,

--- a/src/osekit/public_api/dataset.py
+++ b/src/osekit/public_api/dataset.py
@@ -200,6 +200,7 @@ class Dataset:
             begin=analysis.begin,
             end=analysis.end,
             data_duration=analysis.data_duration,
+            mode=analysis.mode,
             name=analysis.name,
             instrument=self.instrument,
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -174,4 +174,4 @@ def base_dataset(tmp_path: Path) -> BaseDataset:
         BaseFile(path=file, begin=timestamp, end=timestamp + pd.Timedelta(seconds=1))
         for file, timestamp in zip(files, timestamps, strict=False)
     ]
-    return BaseDataset.from_files(files=bfs, bound="files")
+    return BaseDataset.from_files(files=bfs, mode="files")

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -757,7 +757,7 @@ def test_audio_resample_quality(
 
 
 @pytest.mark.parametrize(
-    ("audio_files", "begin", "end", "bound", "duration", "expected_audio_data"),
+    ("audio_files", "begin", "end", "mode", "duration", "expected_audio_data"),
     [
         pytest.param(
             {
@@ -769,7 +769,7 @@ def test_audio_resample_quality(
             },
             None,
             None,
-            "data_duration",
+            "timedelta_total",
             None,
             generate_sample_audio(1, 48_000),
             id="one_entire_file",
@@ -784,7 +784,7 @@ def test_audio_resample_quality(
             },
             None,
             None,
-            "data_duration",
+            "timedelta_total",
             pd.Timedelta(seconds=1),
             generate_sample_audio(
                 nb_files=3,
@@ -804,7 +804,7 @@ def test_audio_resample_quality(
             },
             None,
             None,
-            "data_duration",
+            "timedelta_total",
             pd.Timedelta(seconds=1),
             [
                 generate_sample_audio(nb_files=1, nb_samples=96_000)[0][0:48_000],
@@ -829,7 +829,7 @@ def test_audio_resample_quality(
             },
             None,
             None,
-            "data_duration",
+            "timedelta_total",
             pd.Timedelta(seconds=1),
             generate_sample_audio(nb_files=2, nb_samples=48_000),
             id="overlapping_files",
@@ -852,7 +852,7 @@ def test_audio_resample_quality(
                 nb_samples=48_000,
                 series_type="increase",
             ),
-            id="files_bound_without_overlap",
+            id="files_mode_without_overlap",
         ),
         pytest.param(
             {
@@ -871,7 +871,7 @@ def test_audio_resample_quality(
                 generate_sample_audio(nb_files=1, nb_samples=96_000)[0][0:48_000],
                 generate_sample_audio(nb_files=1, nb_samples=96_000)[0][48_000:],
             ],
-            id="files_bound_with_gap",
+            id="files_mode_with_gap",
         ),
         pytest.param(
             {
@@ -891,7 +891,7 @@ def test_audio_resample_quality(
                 generate_sample_audio(nb_files=1, nb_samples=48_000)[0][0:24_000],
                 generate_sample_audio(nb_files=1, nb_samples=48_000)[0],
             ],
-            id="files_bound_with_overlap",
+            id="files_mode_with_overlap",
         ),
     ],
     indirect=["audio_files"],
@@ -901,7 +901,7 @@ def test_audio_dataset_from_folder(
     audio_files: tuple[list[Path], pytest.fixtures.Subrequest],
     begin: pd.Timestamp | None,
     end: pd.Timestamp | None,
-    bound: Literal["files", "timedelta"],
+    mode: Literal["files", "timedelta_total", "timedelta_file"],
     duration: pd.Timedelta | None,
     expected_audio_data: list[np.ndarray],
 ) -> None:
@@ -910,7 +910,7 @@ def test_audio_dataset_from_folder(
         strptime_format=TIMESTAMP_FORMAT_EXPORTED_FILES_UNLOCALIZED,
         begin=begin,
         end=end,
-        bound=bound,
+        mode=mode,
         data_duration=duration,
     )
     for idx, data in enumerate(dataset.data):

--- a/tests/test_core_api_base.py
+++ b/tests/test_core_api_base.py
@@ -557,7 +557,7 @@ def test_base_dataset_file_bound(
 ) -> None:
     ds = BaseDataset.from_files(
         files=files,
-        bound=bound,
+        mode=bound,
         data_duration=data_duration,
     )
 

--- a/tests/test_core_api_base.py
+++ b/tests/test_core_api_base.py
@@ -361,7 +361,7 @@ def test_dataset_move(
 
 
 @pytest.mark.parametrize(
-    ("files", "bound", "data_duration", "expected_data"),
+    ("files", "mode", "data_duration", "expected_data"),
     [
         pytest.param(
             [
@@ -371,7 +371,7 @@ def test_dataset_move(
                     end=Timestamp("2022-04-22 12:12:13"),
                 ),
             ],
-            "timedelta",
+            "timedelta_total",
             None,
             [
                 (
@@ -382,7 +382,7 @@ def test_dataset_move(
                     ["cool"],
                 ),
             ],
-            id="timedelta_bound_with_no_duration",
+            id="timedelta_mode_with_no_duration",
         ),
         pytest.param(
             [
@@ -392,7 +392,7 @@ def test_dataset_move(
                     end=Timestamp("2022-04-22 12:12:13"),
                 ),
             ],
-            "timedelta",
+            "timedelta_total",
             Timedelta(seconds=0.5),
             [
                 (
@@ -410,7 +410,7 @@ def test_dataset_move(
                     ["cool"],
                 ),
             ],
-            id="timedelta_bound_with_duration",
+            id="timedelta_mode_with_duration",
         ),
         pytest.param(
             [
@@ -425,7 +425,7 @@ def test_dataset_move(
                     end=Timestamp("2022-04-22 12:12:14"),
                 ),
             ],
-            "timedelta",
+            "timedelta_total",
             Timedelta(seconds=0.5),
             [
                 (
@@ -457,7 +457,7 @@ def test_dataset_move(
                     ["fun"],
                 ),
             ],
-            id="timedelta_bound_with_duration_multiple_files",
+            id="timedelta_mode_with_duration_multiple_files",
         ),
         pytest.param(
             [
@@ -478,7 +478,7 @@ def test_dataset_move(
                     ["cool"],
                 ),
             ],
-            id="files_bound_with_one_file",
+            id="files_mode_with_one_file",
         ),
         pytest.param(
             [
@@ -511,7 +511,7 @@ def test_dataset_move(
                     ["fun"],
                 ),
             ],
-            id="files_bound_with_multiple_files",
+            id="files_mode_with_multiple_files",
         ),
         pytest.param(
             [
@@ -544,20 +544,20 @@ def test_dataset_move(
                     ["fun"],
                 ),
             ],
-            id="files_bound_ignores_data_duration",
+            id="files_mode_ignores_data_duration",
         ),
     ],
 )
-def test_base_dataset_file_bound(
+def test_base_dataset_file_mode(
     tmp_path: pytest.fixture,
     files: list[BaseFile],
-    bound: Literal["files", "timedelta"],
+    mode: Literal["files", "timedelta_total"],
     data_duration: Timedelta | None,
     expected_data: list[tuple[Event, str]],
 ) -> None:
     ds = BaseDataset.from_files(
         files=files,
-        mode=bound,
+        mode=mode,
         data_duration=data_duration,
     )
 
@@ -1075,3 +1075,634 @@ def test_data_name(data: BaseData, name: str | None, expected: str) -> None:
     data.name = name
     assert data.name == expected
     assert str(data) == expected
+
+
+@pytest.mark.parametrize(
+    ("files", "begin", "end", "data_duration", "mode", "expected"),
+    [
+        pytest.param(
+            [
+                BaseFile(
+                    "cherry",
+                    begin=Timestamp("2015-08-28 12:12:12"),
+                    end=Timestamp("2015-08-28 12:13:12"),
+                ),
+            ],
+            Timestamp("2015-08-28 12:12:12"),
+            Timestamp("2015-08-28 12:13:12"),
+            Timedelta(seconds=30),
+            "timedelta_total",
+            [
+                [
+                    (
+                        Event(
+                            begin=Timestamp("2015-08-28 12:12:12"),
+                            end=Timestamp("2015-08-28 12:12:42"),
+                        ),
+                        "cherry",
+                    ),
+                ],
+                [
+                    (
+                        Event(
+                            begin=Timestamp("2015-08-28 12:12:42"),
+                            end=Timestamp("2015-08-28 12:13:12"),
+                        ),
+                        "cherry",
+                    ),
+                ],
+            ],
+            id="total_only_one_file",
+        ),
+        pytest.param(
+            [
+                BaseFile(
+                    "depression",
+                    begin=Timestamp("2015-08-28 12:12:12"),
+                    end=Timestamp("2015-08-28 12:13:12"),
+                ),
+                BaseFile(
+                    "cherry",
+                    begin=Timestamp("2015-08-28 12:13:12"),
+                    end=Timestamp("2015-08-28 12:14:12"),
+                ),
+            ],
+            Timestamp("2015-08-28 12:12:12"),
+            Timestamp("2015-08-28 12:14:12"),
+            Timedelta(minutes=1),
+            "timedelta_total",
+            [
+                [
+                    (
+                        Event(
+                            begin=Timestamp("2015-08-28 12:12:12"),
+                            end=Timestamp("2015-08-28 12:13:12"),
+                        ),
+                        "depression",
+                    ),
+                ],
+                [
+                    (
+                        Event(
+                            begin=Timestamp("2015-08-28 12:13:12"),
+                            end=Timestamp("2015-08-28 12:14:12"),
+                        ),
+                        "cherry",
+                    ),
+                ],
+            ],
+            id="total_two_continuous_files_without_overlap",
+        ),
+        pytest.param(
+            [
+                BaseFile(
+                    "depression",
+                    begin=Timestamp("2015-08-28 12:12:12"),
+                    end=Timestamp("2015-08-28 12:13:12"),
+                ),
+                BaseFile(
+                    "cherry",
+                    begin=Timestamp("2015-08-28 12:13:12"),
+                    end=Timestamp("2015-08-28 12:14:12"),
+                ),
+            ],
+            Timestamp("2015-08-28 12:12:12"),
+            Timestamp("2015-08-28 12:14:12"),
+            Timedelta(seconds=45),
+            "timedelta_total",
+            [
+                [
+                    (
+                        Event(
+                            begin=Timestamp("2015-08-28 12:12:12"),
+                            end=Timestamp("2015-08-28 12:12:57"),
+                        ),
+                        "depression",
+                    ),
+                ],
+                [
+                    (
+                        Event(
+                            begin=Timestamp("2015-08-28 12:12:57"),
+                            end=Timestamp("2015-08-28 12:13:12"),
+                        ),
+                        "depression",
+                    ),
+                    (
+                        Event(
+                            begin=Timestamp("2015-08-28 12:13:12"),
+                            end=Timestamp("2015-08-28 12:13:42"),
+                        ),
+                        "cherry",
+                    ),
+                ],
+                [
+                    (
+                        Event(
+                            begin=Timestamp("2015-08-28 12:13:42"),
+                            end=Timestamp("2015-08-28 12:14:12"),
+                        ),
+                        "cherry",
+                    ),
+                    (
+                        Event(
+                            begin=Timestamp("2015-08-28 12:14:12"),
+                            end=Timestamp("2015-08-28 12:14:27"),
+                        ),
+                        None,
+                    ),
+                ],
+            ],
+            id="total_two_continuous_files_with_overlap",
+        ),
+        pytest.param(
+            [
+                BaseFile(
+                    "cherry",
+                    begin=Timestamp("2015-08-28 12:12:12"),
+                    end=Timestamp("2015-08-28 12:13:12"),
+                ),
+            ],
+            Timestamp("2015-08-28 12:12:12"),
+            Timestamp("2015-08-28 12:13:12"),
+            Timedelta(seconds=30),
+            "timedelta_file",
+            [
+                [
+                    (
+                        Event(
+                            begin=Timestamp("2015-08-28 12:12:12"),
+                            end=Timestamp("2015-08-28 12:12:42"),
+                        ),
+                        "cherry",
+                    ),
+                ],
+                [
+                    (
+                        Event(
+                            begin=Timestamp("2015-08-28 12:12:42"),
+                            end=Timestamp("2015-08-28 12:13:12"),
+                        ),
+                        "cherry",
+                    ),
+                ],
+            ],
+            id="file_only_one_file",
+        ),
+        pytest.param(
+            [
+                BaseFile(
+                    "depression",
+                    begin=Timestamp("2015-08-28 12:12:12"),
+                    end=Timestamp("2015-08-28 12:13:12"),
+                ),
+                BaseFile(
+                    "cherry",
+                    begin=Timestamp("2015-08-28 12:13:12"),
+                    end=Timestamp("2015-08-28 12:14:12"),
+                ),
+            ],
+            Timestamp("2015-08-28 12:12:12"),
+            Timestamp("2015-08-28 12:14:12"),
+            Timedelta(minutes=1),
+            "timedelta_file",
+            [
+                [
+                    (
+                        Event(
+                            begin=Timestamp("2015-08-28 12:12:12"),
+                            end=Timestamp("2015-08-28 12:13:12"),
+                        ),
+                        "depression",
+                    ),
+                ],
+                [
+                    (
+                        Event(
+                            begin=Timestamp("2015-08-28 12:13:12"),
+                            end=Timestamp("2015-08-28 12:14:12"),
+                        ),
+                        "cherry",
+                    ),
+                ],
+            ],
+            id="file_two_continuous_files_without_overlap",
+        ),
+        pytest.param(
+            [
+                BaseFile(
+                    "depression",
+                    begin=Timestamp("2015-08-28 12:12:12"),
+                    end=Timestamp("2015-08-28 12:13:12"),
+                ),
+                BaseFile(
+                    "cherry",
+                    begin=Timestamp("2015-08-28 12:13:12"),
+                    end=Timestamp("2015-08-28 12:14:12"),
+                ),
+            ],
+            Timestamp("2015-08-28 12:12:12"),
+            Timestamp("2015-08-28 12:14:12"),
+            Timedelta(seconds=45),
+            "timedelta_file",
+            [
+                [
+                    (
+                        Event(
+                            begin=Timestamp("2015-08-28 12:12:12"),
+                            end=Timestamp("2015-08-28 12:12:57"),
+                        ),
+                        "depression",
+                    ),
+                ],
+                [
+                    (
+                        Event(
+                            begin=Timestamp("2015-08-28 12:12:57"),
+                            end=Timestamp("2015-08-28 12:13:12"),
+                        ),
+                        "depression",
+                    ),
+                    (
+                        Event(
+                            begin=Timestamp("2015-08-28 12:13:12"),
+                            end=Timestamp("2015-08-28 12:13:42"),
+                        ),
+                        "cherry",
+                    ),
+                ],
+                [
+                    (
+                        Event(
+                            begin=Timestamp("2015-08-28 12:13:42"),
+                            end=Timestamp("2015-08-28 12:14:12"),
+                        ),
+                        "cherry",
+                    ),
+                    (
+                        Event(
+                            begin=Timestamp("2015-08-28 12:14:12"),
+                            end=Timestamp("2015-08-28 12:14:27"),
+                        ),
+                        None,
+                    ),
+                ],
+            ],
+            id="file_two_continuous_files_with_overlap",
+        ),
+        pytest.param(
+            [
+                BaseFile(
+                    "depression",
+                    begin=Timestamp("2015-08-28 12:12:12"),
+                    end=Timestamp("2015-08-28 12:13:22"),
+                ),
+                BaseFile(
+                    "cherry",
+                    begin=Timestamp("2015-08-28 12:13:32"),
+                    end=Timestamp("2015-08-28 12:14:12"),
+                ),
+            ],
+            Timestamp("2015-08-28 12:12:12"),
+            Timestamp("2015-08-28 12:14:12"),
+            Timedelta(minutes=1),
+            "timedelta_total",
+            [
+                [
+                    (
+                        Event(
+                            begin=Timestamp("2015-08-28 12:12:12"),
+                            end=Timestamp("2015-08-28 12:13:12"),
+                        ),
+                        "depression",
+                    ),
+                ],
+                [
+                    (
+                        Event(
+                            begin=Timestamp("2015-08-28 12:13:12"),
+                            end=Timestamp("2015-08-28 12:13:22"),
+                        ),
+                        "depression",
+                    ),
+                    (
+                        Event(
+                            begin=Timestamp("2015-08-28 12:13:22"),
+                            end=Timestamp("2015-08-28 12:13:32"),
+                        ),
+                        None,
+                    ),
+                    (
+                        Event(
+                            begin=Timestamp("2015-08-28 12:13:32"),
+                            end=Timestamp("2015-08-28 12:14:12"),
+                        ),
+                        "cherry",
+                    ),
+                ],
+            ],
+            id="total_two_separate_files_without_empty_start",
+        ),
+        pytest.param(
+            [
+                BaseFile(
+                    "depression",
+                    begin=Timestamp("2015-08-28 12:12:12"),
+                    end=Timestamp("2015-08-28 12:13:22"),
+                ),
+                BaseFile(
+                    "cherry",
+                    begin=Timestamp("2015-08-28 12:13:32"),
+                    end=Timestamp("2015-08-28 12:14:12"),
+                ),
+            ],
+            Timestamp("2015-08-28 12:12:12"),
+            Timestamp("2015-08-28 12:14:12"),
+            Timedelta(minutes=1),
+            "timedelta_file",
+            [
+                [
+                    (
+                        Event(
+                            begin=Timestamp("2015-08-28 12:12:12"),
+                            end=Timestamp("2015-08-28 12:13:12"),
+                        ),
+                        "depression",
+                    ),
+                ],
+                [
+                    (
+                        Event(
+                            begin=Timestamp("2015-08-28 12:13:12"),
+                            end=Timestamp("2015-08-28 12:13:22"),
+                        ),
+                        "depression",
+                    ),
+                    (
+                        Event(
+                            begin=Timestamp("2015-08-28 12:13:22"),
+                            end=Timestamp("2015-08-28 12:13:32"),
+                        ),
+                        None,
+                    ),
+                    (
+                        Event(
+                            begin=Timestamp("2015-08-28 12:13:32"),
+                            end=Timestamp("2015-08-28 12:14:12"),
+                        ),
+                        "cherry",
+                    ),
+                ],
+            ],
+            id="file_two_separate_files_without_empty_start",
+        ),
+        pytest.param(
+            [
+                BaseFile(
+                    "depression",
+                    begin=Timestamp("2015-08-28 12:12:12"),
+                    end=Timestamp("2015-08-28 12:13:02"),
+                ),
+                BaseFile(
+                    "cherry",
+                    begin=Timestamp("2015-08-28 12:13:22"),
+                    end=Timestamp("2015-08-28 12:14:12"),
+                ),
+            ],
+            Timestamp("2015-08-28 12:12:12"),
+            Timestamp("2015-08-28 12:14:12"),
+            Timedelta(minutes=1),
+            "timedelta_total",
+            [
+                [
+                    (
+                        Event(
+                            begin=Timestamp("2015-08-28 12:12:12"),
+                            end=Timestamp("2015-08-28 12:13:02"),
+                        ),
+                        "depression",
+                    ),
+                    (
+                        Event(
+                            begin=Timestamp("2015-08-28 12:13:02"),
+                            end=Timestamp("2015-08-28 12:13:12"),
+                        ),
+                        None,
+                    ),
+                ],
+                [
+                    (
+                        Event(
+                            begin=Timestamp("2015-08-28 12:13:12"),
+                            end=Timestamp("2015-08-28 12:13:22"),
+                        ),
+                        None,
+                    ),
+                    (
+                        Event(
+                            begin=Timestamp("2015-08-28 12:13:22"),
+                            end=Timestamp("2015-08-28 12:14:12"),
+                        ),
+                        "cherry",
+                    ),
+                ],
+            ],
+            id="total_two_separate_files_with_empty_start",
+        ),
+        pytest.param(
+            [
+                BaseFile(
+                    "depression",
+                    begin=Timestamp("2015-08-28 12:12:12"),
+                    end=Timestamp("2015-08-28 12:13:02"),
+                ),
+                BaseFile(
+                    "cherry",
+                    begin=Timestamp("2015-08-28 12:13:22"),
+                    end=Timestamp("2015-08-28 12:14:12"),
+                ),
+            ],
+            Timestamp("2015-08-28 12:12:12"),
+            Timestamp("2015-08-28 12:14:12"),
+            Timedelta(minutes=1),
+            "timedelta_file",
+            [
+                [
+                    (
+                        Event(
+                            begin=Timestamp("2015-08-28 12:12:12"),
+                            end=Timestamp("2015-08-28 12:13:02"),
+                        ),
+                        "depression",
+                    ),
+                    (
+                        Event(
+                            begin=Timestamp("2015-08-28 12:13:02"),
+                            end=Timestamp("2015-08-28 12:13:12"),
+                        ),
+                        None,
+                    ),
+                ],
+                [
+                    (
+                        Event(
+                            begin=Timestamp("2015-08-28 12:13:22"),
+                            end=Timestamp("2015-08-28 12:14:12"),
+                        ),
+                        "cherry",
+                    ),
+                    (
+                        Event(
+                            begin=Timestamp("2015-08-28 12:14:12"),
+                            end=Timestamp("2015-08-28 12:14:22"),
+                        ),
+                        None,
+                    ),
+                ],
+            ],
+            id="file_two_separate_files_with_empty_start",
+        ),
+        pytest.param(
+            [
+                BaseFile(
+                    "depression",
+                    begin=Timestamp("2015-08-28 12:12:00"),
+                    end=Timestamp("2015-08-28 12:13:02"),
+                ),
+                BaseFile(
+                    "cherry",
+                    begin=Timestamp("2015-08-28 12:13:22"),
+                    end=Timestamp("2015-08-28 12:14:12"),
+                ),
+            ],
+            Timestamp("2015-08-28 12:12:12"),
+            Timestamp("2015-08-28 12:14:12"),
+            Timedelta(minutes=1),
+            "timedelta_total",
+            [
+                [
+                    (
+                        Event(
+                            begin=Timestamp("2015-08-28 12:12:12"),
+                            end=Timestamp("2015-08-28 12:13:02"),
+                        ),
+                        "depression",
+                    ),
+                    (
+                        Event(
+                            begin=Timestamp("2015-08-28 12:13:02"),
+                            end=Timestamp("2015-08-28 12:13:12"),
+                        ),
+                        None,
+                    ),
+                ],
+                [
+                    (
+                        Event(
+                            begin=Timestamp("2015-08-28 12:13:12"),
+                            end=Timestamp("2015-08-28 12:13:22"),
+                        ),
+                        None,
+                    ),
+                    (
+                        Event(
+                            begin=Timestamp("2015-08-28 12:13:22"),
+                            end=Timestamp("2015-08-28 12:14:12"),
+                        ),
+                        "cherry",
+                    ),
+                ],
+            ],
+            id="total_two_separate_files_begin_mid_file",
+        ),
+        pytest.param(
+            [
+                BaseFile(
+                    "depression",
+                    begin=Timestamp("2015-08-28 12:12:00"),
+                    end=Timestamp("2015-08-28 12:13:02"),
+                ),
+                BaseFile(
+                    "cherry",
+                    begin=Timestamp("2015-08-28 12:13:22"),
+                    end=Timestamp("2015-08-28 12:14:12"),
+                ),
+            ],
+            Timestamp("2015-08-28 12:12:12"),
+            Timestamp("2015-08-28 12:14:12"),
+            Timedelta(minutes=1),
+            "timedelta_file",
+            [
+                [
+                    (
+                        Event(
+                            begin=Timestamp("2015-08-28 12:12:00"),
+                            end=Timestamp("2015-08-28 12:13:00"),
+                        ),
+                        "depression",
+                    ),
+                ],
+                [
+                    (
+                        Event(
+                            begin=Timestamp("2015-08-28 12:13:00"),
+                            end=Timestamp("2015-08-28 12:13:02"),
+                        ),
+                        "depression",
+                    ),
+                    (
+                        Event(
+                            begin=Timestamp("2015-08-28 12:13:02"),
+                            end=Timestamp("2015-08-28 12:13:22"),
+                        ),
+                        None,
+                    ),
+                    (
+                        Event(
+                            begin=Timestamp("2015-08-28 12:13:22"),
+                            end=Timestamp("2015-08-28 12:14:00"),
+                        ),
+                        "cherry",
+                    ),
+                ],
+                [
+                    (
+                        Event(
+                            begin=Timestamp("2015-08-28 12:14:00"),
+                            end=Timestamp("2015-08-28 12:14:12"),
+                        ),
+                        "cherry",
+                    ),
+                    (
+                        Event(
+                            begin=Timestamp("2015-08-28 12:14:12"),
+                            end=Timestamp("2015-08-28 12:15:00"),
+                        ),
+                        None,
+                    ),
+                ],
+            ],
+            id="file_two_separate_files_begin_mid_file",
+        ),
+    ],
+)
+def test_get_base_data_from_files(
+    files: list[BaseFile],
+    begin: Timestamp,
+    end: Timestamp,
+    data_duration: Timedelta,
+    mode: Literal["timedelta_total", "timedelta_file"],
+    expected: list[list[tuple[Event, str | None]]],
+) -> None:
+    data = BaseDataset.from_files(files, begin, end, mode, data_duration).data
+
+    for d, e in zip(data, expected, strict=True):
+        for item, expected_tuple in zip(d.items, e, strict=True):
+            expected_item, expected_filename = expected_tuple
+            assert item.begin == expected_item.begin
+            assert item.end == expected_item.end
+            assert (
+                expected_filename is None
+                if item.is_empty
+                else item.file.path.name == expected_filename
+            )

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -242,7 +242,7 @@ def test_dataset_build(
     original_dataset = AudioDataset.from_folder(
         tmp_path,
         strptime_format=files_timestamp_format,
-        bound="files",
+        mode="files",
         timezone=dataset_timezone,
         name="original",
     )
@@ -266,7 +266,7 @@ def test_dataset_build(
     assert moved_original_dataset == AudioDataset.from_folder(
         folder=tmp_path / "data" / "audio" / "original",
         strptime_format=files_timestamp_format,
-        bound="files",
+        mode="files",
         timezone=dataset_timezone,
     )
 

--- a/tests/test_welch.py
+++ b/tests/test_welch.py
@@ -114,7 +114,7 @@ def test_welch_spectrodataset(
     instrument: Instrument | None,
 ) -> None:
     afs, _ = audio_files
-    ads = AudioDataset.from_files(files=afs, instrument=instrument, bound="files")
+    ads = AudioDataset.from_files(files=afs, instrument=instrument, mode="files")
     sds = SpectroDataset.from_audio_dataset(ads, fft=sft)
 
     folder = afs[0].path.parent / "output"


### PR DESCRIPTION
# 🐳What's new ?

This PR introduces the `BaseDataset.from_files()` `mode` parameter.

# 🐳What does it do ??

The `mode` corresponds to the way the `BaseData` are created from the `BaseFile` objects:

|mode|definition|
|:---|---:|
|`"file"`|A `BaseData` will be created per `BaseFile`, regardless of `data_duration`.|
|`"timedelta_total"`|A `data_duration`-long `BaseData` will be created from the `begin` Timestamp to the `end` Timestamp, regardless of the `BaseFile`s coverage.|
|`"timedelta_file"`|A `data_duration`-long `BaseData` will be created from the beginning of the first file containing the `begin` Timestamp to the `end` Timestamp. If this would result in a `BaseData` beginning **between two files**, it will begin at the **beginning of the next `BaseFile` instead**.|

# 🐳 When to use which ?

The `timedelta_file` mode was the original (and default) mode: it allows for a continuous coverage of the segments between the begin and end timestamp.

However, in cases e.g. of recording with a duty cycle, the default mode would result in lots of empty data, and series of data that are uncorrelated to the recorded files.

## 🐋Example

Example with `45 s`-long spectrograms plotted from a set of `30 s`-long audio files recorded with a **50%** duty cycle.

### 🐬Default `timedelta_total` mode:

<img width="1549" height="748" alt="total" src="https://github.com/user-attachments/assets/76eeb395-f49f-4bd0-82e0-b69fdcc30c82" />

The 50% alterance between recording and sleep is clearly visible, but each audio segment starts at a different time relative to the recording phases.

### 🐬`timedelta_file` mode:

<img width="1551" height="546" alt="file" src="https://github.com/user-attachments/assets/4ebe7781-c0c4-4e95-89e8-83ce3a970663" />

No audio segment begin during sleep, as a `15 s`-long segment of sleep time was skipped after each data instance.

Note: The data can be further trimmed, e.g. for removing the remaining sleep time:

```py
ads = AudioDataset.from_files(..., mode="timedelta_file")

# Filtering the AudioData to remove the empty items:
ads.data = [AudioData([item for item in d.items if not item.is_empty]) for d in ads.data]
```

In this case, this would lead to the same output as using the `file` mode:

<img width="1548" height="535" alt="file_filtered" src="https://github.com/user-attachments/assets/71f7bcfb-7dcf-40ed-8ae8-4b7c27fa67c9" />

However, if `data_duration` is lower than the recorded files duration, this would result in a mismatch in duration within the `AudioData` objects!

# 🐳Public API usage

To select a mode in the Public API, simply specify it as a parameter to the `Analysis` constructor:

```py
from osekit.public_api.dataset import Dataset
from osekit.public_api.analysis import Analysis, AnalysisType

dataset = Dataset(...)

analysis=Analysis(
    analysis_type=AnalysisType.SPECTROGRAM,
    data_duration = Timedelta(seconds=45),
    mode = "timedelta_file",
    fft=sft,
)

dataset.run_analysis(analysis)

# You can still use some CoreAPI to further filter the output data if you want:
ads = dataset.get_analysis_audiodataset(analysis)
ads.data = [AudioData([item for item in d.items if not item.is_empty]) for d in ads.data]
dataset.run_analysis(analysis, audio_dataset=ads)
```
