### PR TITLE
Multiprocessing

### DIFF
--- a/src/osekit/config.py
+++ b/src/osekit/config.py
@@ -21,3 +21,5 @@ resample_quality_settings = {
     "downsample": "QQ",
     "upsample": "MQ",
 }
+
+nb_processes = 1

--- a/src/osekit/core_api/ltas_data.py
+++ b/src/osekit/core_api/ltas_data.py
@@ -19,14 +19,13 @@ and each part is replaced with an average of the stft performed within it.
 
 from __future__ import annotations
 
-import multiprocessing as mp
 from typing import TYPE_CHECKING
 
 import numpy as np
 from scipy.signal import ShortTimeFFT
-from tqdm import tqdm
 
 from osekit.core_api.spectro_data import SpectroData
+from osekit.utils.multiprocess_utils import multiprocess
 
 if TYPE_CHECKING:
     from pandas import Timestamp
@@ -138,17 +137,12 @@ class LTASData(SpectroData):
 
         if depth != 0:
             return np.vstack(
-                [self.mean_value_part(sub_spectro) for sub_spectro in sub_spectros]
+                [self.mean_value_part(sub_spectro) for sub_spectro in sub_spectros],
             ).T
 
-        with mp.Pool(processes=5) as pool:
-            means = list(
-                tqdm(
-                    pool.imap(self.mean_value_part, sub_spectros),
-                    total=len(sub_spectros),
-                )
-            )
-            return np.vstack(means).T
+        return np.vstack(
+            list(multiprocess(self.mean_value_part, sub_spectros)),
+        ).T
 
     @classmethod
     def from_spectro_data(

--- a/src/osekit/public_api/dataset.py
+++ b/src/osekit/public_api/dataset.py
@@ -14,6 +14,7 @@ import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, TypeVar
 
+from osekit import config
 from osekit.config import DPDEFAULT, resample_quality_settings
 from osekit.core_api.audio_dataset import AudioDataset
 from osekit.core_api.base_dataset import BaseDataset
@@ -414,7 +415,8 @@ class Dataset:
                 f"--last {stop} "
                 f"--downsampling-quality {resample_quality_settings['downsample']} "
                 f"--upsampling-quality {resample_quality_settings['upsample']} "
-                f"--umask {get_umask()} ",
+                f"--umask {get_umask()} "
+                f"--nb-processes {config.nb_processes} ",
                 jobname="OSmOSE_Analysis",
                 preset="low",
                 env_name=sys.executable.replace("/bin/python", ""),

--- a/src/osekit/public_api/export_analysis.py
+++ b/src/osekit/public_api/export_analysis.py
@@ -5,6 +5,7 @@ import os
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from osekit import config
 from osekit.config import global_logging_context as glc
 from osekit.config import resample_quality_settings
 from osekit.public_api.analysis import AnalysisType
@@ -227,15 +228,22 @@ if __name__ == "__main__":
         help="The umask to apply on the created file permissions.",
     )
     parser.add_argument(
-        "--tqdm_disable",
+        "--tqdm-disable",
         type=int,
         default=1,
         help="Disable TQDM progress bars.",
+    )
+    parser.add_argument(
+        "--nb-processes",
+        type=int,
+        default=1,
+        help="Set the number of processes to use.",
     )
 
     args = parser.parse_args()
 
     os.environ["DISABLE_TQDM"] = "" if not args.tqdm_disable else str(args.tqdm_disable)
+    config.nb_processes = args.nb_processes
 
     os.umask(args.umask)
 

--- a/src/osekit/utils/multiprocess_utils.py
+++ b/src/osekit/utils/multiprocess_utils.py
@@ -1,0 +1,49 @@
+"""Multiprocessing module that helps running functions on collections using multiple threads."""
+
+import multiprocessing as mp
+import os
+from typing import Any
+
+from tqdm import tqdm
+
+from osekit import config
+
+
+def multiprocess(
+    func: callable, enumerable: list, *args: tuple[Any, ...], **kwargs: dict[str, Any]
+) -> list[Any]:
+    """Run a given callable function on an enumerable.
+
+    The function is run through osekit.config.nb_processes threads.
+
+    Parameters
+    ----------
+    func: callable
+        The function to run.
+    enumerable: list
+        The list of input to the function.
+    args:
+        Additional positional arguments to pass to the function.
+    kwargs:
+        Additional keyword arguments to pass to the function.
+
+    Returns
+    -------
+    list[Any]:
+        Returned values of the function.
+
+    """
+    if config.nb_processes == 1:
+        return list(
+            func(element, *args, **kwargs)
+            for element in tqdm(enumerable, disable=os.environ.get("DISABLE_TQDM", ""))
+        )
+
+    with mp.Pool(config.nb_processes) as pool:
+        return list(
+            tqdm(
+                pool.imap(func, enumerable),
+                total=len(list(enumerable)),
+                disable=os.environ.get("DISABLE_TQDM", ""),
+            ),
+        )

--- a/src/osekit/utils/multiprocess_utils.py
+++ b/src/osekit/utils/multiprocess_utils.py
@@ -2,6 +2,7 @@
 
 import multiprocessing as mp
 import os
+from functools import partial
 from typing import Any
 
 from tqdm import tqdm
@@ -10,7 +11,10 @@ from osekit import config
 
 
 def multiprocess(
-    func: callable, enumerable: list, *args: tuple[Any, ...], **kwargs: dict[str, Any]
+    func: callable,
+    enumerable: list,
+    *args: Any,
+    **kwargs: Any,
 ) -> list[Any]:
     """Run a given callable function on an enumerable.
 
@@ -39,10 +43,12 @@ def multiprocess(
             for element in tqdm(enumerable, disable=os.environ.get("DISABLE_TQDM", ""))
         )
 
+    partial_func = partial(func, *args, **kwargs)
+
     with mp.Pool(config.nb_processes) as pool:
         return list(
             tqdm(
-                pool.imap(func, enumerable),
+                pool.imap(partial_func, enumerable),
                 total=len(list(enumerable)),
                 disable=os.environ.get("DISABLE_TQDM", ""),
             ),


### PR DESCRIPTION
# 🐳What's new?

This PR add the ability to dispatch the Core API Datasets computings over multiple threads.

## 🐳How do I use multiple threads??

You just have to set the `osekit.config.nb_processes` to any value `>1`:

```py
from osekit import config

config.nb_processes = 5 # From now on, any computing done in core API Datasets will be distributed over 5 threads.
```

This is also valid for the **Public API** and for **working with PBS jobs**: servers that run analyses launched through the public API will use `config.nb_processes` threads to compute stuff.

## 🐳Where does it happen?

All the methods that compute stuff over several core API Data (e.g. `AudioDataset.write()`, `SpectroDataset.save_spectrogram()`, etc.), along with the LTAS computation (`osekit.core_api.ltas_data.LTASData.get_value()`) now use multiprocessing if `nb_processes > 1`.

## 🐳How does it work under the hood?

This PR add a `osekit.utils.multiprocess_utils.py` module, this is where all the shenanigan happens:

The methods that compute stuff over several core API Data (e.g. `AudioDataset.write()`, `SpectroDataset.save_spectrogram()`, etc.) now call the `osekit.utils.multiprocess_utils.multiprocess` function.

This function takes as parameter:

|Name|Type|Description|
|:---|:---|---:|
|func|callable|The function to apply to the collection of Data: e.g. the `SpectroData.save_spectrogram()` method. Because it has to be accessed in the multiprocess agents (and thus within the calling class), methods like `SpectroDataset._save_spectrogram()` were added.|
|enumerable|list|The collection on which `func` is called. Typically the `AudioDataset.data` or `SpectroDataset.data` list.|
|*args, **kwargs|tuple,dict|Additional parameters that might be passed to `func`. To have this working with multiprocessing, `func` and the extra args are turned into a `functool.partial` function within the `multiprocess()` function.|
